### PR TITLE
Prevent frame.add() from choking on leading/trailing whitespace

### DIFF
--- a/src/_q_frame_test.js
+++ b/src/_q_frame_test.js
@@ -321,6 +321,15 @@ describe("FOUNDATION: QFrame", function() {
 			assert.equal(element.toString(), "'<p>foo</p>'", "name should match the HTML created");
 		});
 
+		it("strips leading/trailing whitespace from html passed to .add()", function() {
+			var html = "<p>foo</p>";
+			var htmlWithWhitespace = "  \n  " + html + "  \n  ";
+			var element = frame.add(htmlWithWhitespace);
+			var body = frameDom.contentDocument.body;
+
+			assert.equal(body.innerHTML.toLowerCase(), html, "frame should add the element without whitespace");
+		});
+
 		it("uses optional nickname to describe added elements", function() {
 			var element = frame.add("<p>foo</p>", "my element");
 			assert.equal(element.toString(), "'my element'");

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -199,7 +199,7 @@
 		ensureUsable(this);
 
 		var tempElement = document.createElement("div");
-		tempElement.innerHTML = html;
+		tempElement.innerHTML = html.replace(/^\s*|\s*$/gm, '');
 		ensure.that(
 			tempElement.childNodes.length === 1,
 			"Expected one element, but got " + tempElement.childNodes.length + " (" + html + ")"


### PR DESCRIPTION
Hey @jamesshore,

This PR just strips leading / trailing whitespace from `html` passing into `frame.add()` before assigning it to `tempElement.innerHTML`.

I just discovered Quixote and am very excited about it, but when I just tried to write my first test, doing something like this:

```javascript
frame.add(`
  <div id="container">
    <p id="paragraph">
      This is a paragraph.
    </p>
  </div>
`)
```

I got this error:
```
Expected one element, but got 3
```

It seems like when doing `tempElement.innerHTML = html` ([here](https://github.com/jamesshore/quixote/blob/master/src/q_frame.js#L202)), it's creating text nodes with the whitespace, which makes the subsequent check for only 1 childNode fail.
