### PR TITLE
Fix broken assertion in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ describe("Button", function() {
   
   it("has styled text", function() {
     assert.equal(button.getRawStyle("text-align"), "center", "should be centered");
-    assert.equal(button.getRawStyle("text-decoration"), "underline", "should be underlined");
+    assert.equal(button.getRawStyle("text-decoration"), "none", "should not be underlined");
     assert.equal(button.getRawStyle("text-transform"), "uppercase", "should be uppercase");
   });
 


### PR DESCRIPTION
Unless I'm misunderstanding, I think the tests will currently fail. At least they did for me as I tried to implement this.

The button in the example will actually have no underline, based on [this line in the css](https://github.com/jamesshore/quixote/compare/master...JuanCaicedo:patch-1#diff-04c6e90faac2675aa89e2176d2eec7d8R95)

This is what it looks like in my browser
<img width="279" alt="screen shot 2017-01-13 at 8 17 22 am" src="https://cloud.githubusercontent.com/assets/4341496/21931293/c425e9f2-d968-11e6-95d1-fd78093127f6.png">
 