### PR TITLE
change main script to src directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "quixote",
   "version": "0.12.3",
   "description": "CSS unit and integration testing",
-  "main": "dist/quixote.js",
+  "main": "src/quixote.js",
   "devDependencies": {
     "browserify": "^13.0.0",
     "gaze": "^1.1.0",


### PR DESCRIPTION
I was having some trouble using browserify to build my karma tests. I saw that in the example code both browserify and commonjs are. This change makes it possible to just use browserify. You can view some working code using this fork [here](https://github.com/JuanCaicedo/tdd-css). To test it:

```bash
$ git clone https://github.com/JuanCaicedo/tdd-css.git
$ cd tdd-css
$ npm install
$ npm test
```

I think `main` is only used by node, [when determining what to use as an entry point](http://stackoverflow.com/questions/22512992/node-js-package-json-main-parameter), but if you're concerned there might be breaking changes then I can try to come up with some test code.

A potential downsite is that using `dist` as an entry point means that you can have a build step before. That is, you could for example transpile first and have node use the code after it has been transpiled, instead of needing to somehow do it at runtime. This might become a concern in the future