### PR TITLE
Enable passing in a raw css string

### DIFF
--- a/src/_q_frame_test.js
+++ b/src/_q_frame_test.js
@@ -105,11 +105,51 @@ describe("FOUNDATION: QFrame", function() {
 				}
 			});
 		});
+		
+		it("creates iframe using raw CSS only", function(done) {
+			QFrame.create(window.document.body, { css: ".style-me { font-size: 42px; }"	}, function(err, frame) {
+				var styleMe = frame.add("<div class='style-me'>Foo</div>");
+				assert.equal(styleMe.getRawStyle("font-size"), "42px");
+				done();
+			});
+		});
+
+		it("creates iframe using raw CSS and a stylesheet link", function(done) {
+			var options = {
+				css: ".style-me { font-size: 42px; }",
+				stylesheet: "/base/src/_q_frame_test2.css"
+			};
+			frame = QFrame.create(window.document.body, options, function(err) {
+				if (err) return done(err);
+				try {
+					var styleMe = frame.add("<div class='style-me'>Foo</div>");
+					assert.equal(styleMe.getRawStyle("font-size"), "42px", "should get style from raw css");
+					assert.equal(styleMe.getRawPosition().height, 123, "should get style from stylesheet");
+					done();
+				}
+				catch(e) {
+					done(e);
+				}
+			});
+		});
 
 		it("creates iframe using stylesheet and source URL simultaneously", function(done) {
 			var options = {
 				src: "/base/src/_q_frame_test.html",
 				stylesheet: "/base/src/_q_frame_test.css"
+			};
+
+			QFrame.create(window.document.body, options, function(err, frame) {
+				var styleMe = frame.get(".style-me");
+				assert.equal(styleMe.getRawStyle("font-size"), "42px");
+				done();
+			});
+		});
+	  
+		it("creates iframe using raw CSS and source URL simultaneously", function(done) {
+			var options = {
+				src: "/base/src/_q_frame_test.html",
+				css: ".style-me { font-size: 42px; }"
 			};
 
 			QFrame.create(window.document.body, options, function(err, frame) {
@@ -414,7 +454,7 @@ describe("FOUNDATION: QFrame", function() {
         assert.equal(frame.viewport().height.diff(reset.HEIGHT), "", "height");
         done();
       });
-    });
+	});
 
   });
 

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -40,6 +40,7 @@
 		var height = options.height || 2000;
 		var src = options.src;
 		var stylesheets = options.stylesheet || [];
+		var css = options.css;
 		if (!shim.Array.isArray(stylesheets)) stylesheets = [ stylesheets ];
 
 		var err = checkUrls(src, stylesheets);
@@ -59,6 +60,12 @@
 			// We force it to be asynchronous here
 			setTimeout(function() {
 				loaded(frame, width, height, src, stylesheets);
+				if (css) {
+					loadRawCSS(frame, options.css);
+					if (!stylesheets.length) {
+						frame._frameLoadCallback(null, frame);
+					}
+				}
 				loadStylesheets(frame, stylesheets, function() {
 					frame._frameLoadCallback(null, frame);
 				});
@@ -133,6 +140,13 @@
 			link.setAttribute("href", url);
 			shim.Document.head(self._document).appendChild(link);
 		}
+	}
+
+	function loadRawCSS(self, css) {
+		var style = document.createElement("style");
+		style.setAttribute("type", "text/css");
+		style.innerHTML = css;
+		shim.Document.head(self._document).appendChild(style);
 	}
 
 	Me.prototype.reset = function() {


### PR DESCRIPTION
This gives the user flexibility in case they want to load up the css through a module loader and then pass it through as a string.

I'm not very familiar with the frame load callback works. If I put the loadRawCSS call after loadStylesheets it didn't seem to set the styles until after the test assertions run. However, if you don't have a stylesheet, the load callback never gets called. To get around this, I'm currently checking to see if there are no stylesheets and calling the load callback immediately after the raw css is loaded up. I would welcome any feedback on the 'right' way to do this.

https://github.com/jamesshore/quixote/issues/39