### PR TITLE
Add QElement dom node constructor

### DIFF
--- a/docs/QContentHost.md
+++ b/docs/QContentHost.md
@@ -1,0 +1,173 @@
+# Quixote API: `QContentHost`
+
+* [Back to overview README](../README.md)
+* [Back to API overview](api.md)
+
+`QContentHost` instances represent the hosting document and window. You'll use this to create and retrieve elements as well as get access to the viewport and page descriptors.
+
+
+#### contentHost.get()
+
+```
+Stability: 2 - Unstable
+```
+
+Retrieve an element matching a selector. Throws an exception unless exactly one matching element is found. If you don't want the possibility of an exception, use [`contentHost.getAll()`](#contenthostgetall) instead.
+
+`element = contentHost.get(selector, nickname)`
+
+* `element (`[`QElement`](QElement.md)`)` The element that matches your selector.
+
+* `selector (string)` A CSS selector. Any selector that works with [document.querySelectorAll()](https://developer.mozilla.org/en-US/docs/Web/API/Document.querySelectorAll) will work. In particular, note that IE 8 is limited to CSS2 selectors only.
+
+* `nickname (optional string)` The name to use when describing your element in error messages. Uses the selector by default.
+
+Example: `var foo = contentHost.get("#foo");`
+
+
+#### contentHost.getAll()
+
+```
+Stability: 1 - Experimental
+```
+
+Retrieve a list of elements matching a selector. If you want to ensure that exactly one element is retrieved, use [`contentHost.get()`](#contenthostget) instead.
+
+`list = contentHost.getAll(selector, nickname)`
+
+* `list (`[`QElementList`](QElementList.md)`)` The elements that match your selector.
+
+* `selector (string)` A CSS selector. Any selector that works with [document.querySelectorAll()](https://developer.mozilla.org/en-US/docs/Web/API/Document.querySelectorAll) will work. In particular, note that IE 8 is limited to CSS2 selectors only.
+
+* `nickname (optional string)` The name to use when describing your list in error messages. Uses the selector by default.
+
+Example `var fooList = contentHost.getAll(".foo");`
+
+
+#### contentHost.add()
+
+```
+Stability: 2 - Unstable
+```
+
+Create an element and append it to the contentHost's body. Throws an exception unless exactly one element is created. (But that one element may contain children.)
+
+`element = contentHost.add(html, nickname)`
+
+* `element (`[`QElement`](QElement.md)`)` The element you created.
+
+* `html (string)` HTML for your element.
+
+* `nickname (optional string)` The name to use when describing your element in error messages. Uses the html by default.
+
+Example: `var foo = contentHost.add("<p>foo</p>", "foo");`
+
+
+#### contentHost.viewport()
+
+```
+Stability: 1 - Experimental
+```
+
+Provides access to descriptors for the contentHost's viewport (the part of the page that is visible in the browser window, not including scrollbars).
+
+`viewport = contentHost.viewport()`
+
+* `viewport (`[`see descriptors`](descriptors.md)`)` Viewport descriptors, plus `assert()` and `diff()` methods equivalent to the ones found on [`QElement`](QElement.md).
+
+Example: Assert that a banner is displayed at the top of the window and all the way from side to side.
+
+```javascript
+var viewport = contentHost.viewport();
+banner.assert({
+  top: viewport.top,
+  left: viewport.left,
+  width: viewport.width
+});
+```
+
+
+#### contentHost.page()
+
+```
+Stability: 1 - Experimental
+```
+
+Provides access to descriptors for the entirety of the contentHost's page (everything you can see or scroll to, not including scrollbars).
+
+`page = contentHost.page()`
+
+* `page (`[`see descriptors`](descriptors.md)`)` Page descriptors, plus `assert()` and `diff()` methods equivalent to the ones found on [`QElement`](QElement.md).
+
+Example: Assert that a sidebar extends the entire height of the page.
+
+```javascript
+var page = contentHost.page();
+sidebar.assert({
+  top: page.top,
+  height: page.height
+});
+```
+
+
+#### contentHost.body()
+
+```
+Stability: 1 - Experimental
+```
+
+Retrieves the contentHost's `body` element.
+
+`body = contentHost.body()`
+
+* `body (`[`QElement`](QElement.md)`)` The body element.
+
+
+#### contentHost.scroll()
+
+```
+Stability: 1 - Experimental
+```
+
+Scroll the page so that top-left corner of the windows content is as close as possible to an (x, y) coordinate. Note that the page may not scroll at all in some cases, such as when the entire page is already visible in the browser window.
+
+`contentHost.scroll(x, y)`
+
+* `x (number)` The x coordinate to scroll to.
+
+* `y (number)` The y coordinate to scroll to.
+
+Example: `contentHost.scroll(50, 60);`
+
+
+#### contentHost.getRawScrollPosition()
+
+```
+Stability: 1 - Experimental
+```
+
+Determine the (x, y) coordinate of the top-left corner of the visible viewport within the windows content. This uses [pageXOffset](https://developer.mozilla.org/en-US/docs/Web/API/Window.scrollX) and [pageYOffset](https://developer.mozilla.org/en-US/docs/Web/API/Window.scrollY) under the covers. (On IE 8, it uses [scrollLeft](http://msdn.microsoft.com/en-us/library/ie/ms534617%28v=vs.85%29.aspx) and [scrollTop](http://msdn.microsoft.com/en-us/library/ie/ms534618%28v=vs.85%29.aspx).)
+
+`position = contentHost.getRawScrollPosition()`
+
+* `position (Object)` The (x, y) coordinate:
+  * `x (number)` The x coordinate.
+  * `y (number)` The y coordinate.
+
+**Compatibility Note:** `getRawScrollPosition` does *not* attempt to resolve cross-browser differences, with one exception:
+
+* IE 8 uses `scrollLeft` and `scrollTop` rather than `pageXOffset` and `pageYOffset`.
+
+
+#### contentHost.toDomElement()
+
+```
+Stability: 1 - Experimental
+```
+
+Retrieve the underlying [`Window`](https://developer.mozilla.org/en-US/docs/Web/API/Window) DOM element for the contentHost.
+
+`dom = contentHost.toDomElement()`
+
+* `dom (`[`Window`](https://developer.mozilla.org/en-US/docs/Web/API/Window)`)` The DOM element.
+

--- a/docs/QElement.md
+++ b/docs/QElement.md
@@ -158,6 +158,19 @@ Get the element's parent element.
 * `parent (QElement or null)` The parent element. Null if this element is the frame's body element or if this element has been removed from the DOM.
 
 
+#### element.host()
+
+```
+Stability: 1 - Experimental
+```
+
+Retrieve the Content Host [`QContentHost`](QContentHost.md) for this element.
+
+`contentHost = element.host()`
+
+* `contentHost (`[`QContentHost`](QContehtHost.md)`)` The Content Host.
+
+
 #### element.toDomElement()
 
 ```

--- a/docs/QFrame.md
+++ b/docs/QFrame.md
@@ -3,7 +3,7 @@
 * [Back to overview README](../README.md)
 * [Back to API overview](api.md)
 
-`QFrame` controls the test frame. You'll use this to create and retrieve elements. Of particular use is [`frame.reset()`](#framereset), which you should call before each test. You'll also call [`frame.remove()`](#frameremove) after all your CSS tests are complete.
+`QFrame` controls the test frame (and is a [`QContentHost`](QContentHost.md)). You'll use this to create and retrieve elements. Of particular use is [`frame.reset()`](#framereset), which you should call before each test. You'll also call [`frame.remove()`](#frameremove) after all your CSS tests are complete.
 
 
 #### frame.reset()
@@ -239,6 +239,19 @@ Determine the (x, y) coordinate of the top-left corner of the frame. This uses [
 **Compatibility Note:** `getRawScrollPosition` does *not* attempt to resolve cross-browser differences, with one exception:
 
 * IE 8 uses `scrollLeft` and `scrollTop` rather than `pageXOffset` and `pageYOffset`.
+
+
+#### frame.toContentHost()
+
+```
+Stability: 1 - Experimental
+```
+
+Retrieve the underlying [`QContentHost`](QContentHost.md) for the frame.
+
+`contentHost = frame.toContentHost()`
+
+* `contentHost (`[`QContentHost`](QContehtHost.md)`)` The Content Host.
 
 
 #### frame.toDomElement()

--- a/docs/quixote.md
+++ b/docs/quixote.md
@@ -46,6 +46,31 @@ before(function(done) {
 **Compatibility Note:** Mobile Safari will increase the size of small fonts depending on the width of the frame. (You can prevent this behavior by using `-webkit-text-size-adjust: 100%;` in your CSS.) You can detect this behavior by using [`quixote.browser.enlargesFonts()`](#quixotebrowser).
 
 
+#### quixote.elementFromDom()
+
+```
+Stability: 1 - Experimental
+```
+
+Create an [`QElement`](QElement.md) from the given dom element. Used when running in the context of another test framework that already is hosting a test iframe (for example [cypress.io](https://www.cypress.io/)).
+
+`element = quixote.elementFromDom(domElement, nickname)`
+
+* `element (`[`QElement`](QElement.md)`)` The newly-created QElement for the given dom element.
+
+* `domElement (HTMLElement)` Dom element to wrap.
+
+* `nickname (optional string)` A friendly description of the dom element used when displaying error messages.
+
+Example:
+
+```javascript
+var testDocument = document; // this would come from the test iframe
+var domElement = testDocument.body.querySelector("p")
+var element = quixote.elementFromDom(domElement);
+```
+
+
 #### quixote.browser
 
 ```

--- a/src/_q_content_host_test.js
+++ b/src/_q_content_host_test.js
@@ -1,0 +1,125 @@
+// Copyright (c) 2014 Titanium I.T. LLC. All rights reserved. For license, see "README" or "LICENSE" file.
+"use strict";
+
+var assert = require("./util/assert.js");
+var quixote = require("./quixote.js");
+var reset = require("./__reset.js");
+var QContentHost = require("./q_content_host");
+var QElement = require("./q_element.js");
+var QViewport = require("./q_viewport.js");
+var QPage = require("./q_page.js");
+
+
+describe("FOUNDATION: QContentHost", function() {
+
+    describe("instance", function() {
+
+        var frame;
+        var contentHost;
+
+        before(function() {
+            frame = reset.frame;
+            contentHost = frame.toContentHost();
+        });
+
+        it("compares to another QContentHost", function() {
+            var contentHost1 = new QContentHost(frame.toDomElement().contentDocument);
+            var contentHost2 = new QContentHost(document);
+
+			assert.objEqual(contentHost, contentHost1, "equality");
+			assert.objNotEqual(contentHost, contentHost2, "inequality");
+		});
+
+        it("provides access to viewport descriptors", function() {
+			assert.type(contentHost.viewport(), QViewport);
+		});
+
+		it("provides access to page descriptors", function() {
+			assert.type(contentHost.page(), QPage);
+        });
+        
+        it("provides access to raw HTML", function() {
+            assert.equal(contentHost.toDomElement(), frame.toDomElement().contentWindow);
+        });
+
+		it("retrieves body element", function() {
+			assert.objEqual(contentHost.body(), new QElement(frame.toDomElement().contentDocument.body, "body"), "body element");
+			assert.equal(contentHost.body().toString(), "'body'", "body description");
+        });
+        
+        it("adds an element", function() {
+			var element = contentHost.add("<p>foo</p>");
+			var body = contentHost.body();
+
+			assert.objEqual(element.parent(), body, "element should be present in contentHost body");
+			assert.equal(element.toString(), "'<p>foo</p>'", "name should match the HTML created");
+		});
+
+		it("uses optional nickname to describe added elements", function() {
+			var element = contentHost.add("<p>foo</p>", "my element");
+			assert.equal(element.toString(), "'my element'");
+		});
+
+		it("retrieves an element by selector", function() {
+			var expected = contentHost.add("<div id='foo' class='bar' baz='boo'>Irrelevant text</div>");
+			var byId = contentHost.get("#foo");
+			var byClass = contentHost.get(".bar");
+			var byAttribute = contentHost.get("[baz]");
+
+			assert.objEqual(byId, expected, "should get element by ID");
+			assert.objEqual(byClass, expected, "should get element by class");
+			assert.objEqual(byAttribute, expected, "should get element by attribute");
+
+			assert.equal(byId.toString(), "'#foo'", "should describe element by selector used");
+		});
+
+		it("uses optional nickname to describe retrieved elements", function() {
+			contentHost.add("<div id='foo'>Irrelevant text</div>");
+			var element = contentHost.get("#foo", "Bestest Element Ever!!");
+			assert.equal(element.toString(), "'Bestest Element Ever!!'");
+		});
+
+		it("fails fast when retrieving non-existant element", function() {
+			assert.exception(function() {
+				contentHost.get(".blah");
+			}, /Expected one element to match '\.blah', but found 0/);
+		});
+
+		it("fails fast when retrieving too many elements", function() {
+			contentHost.add("<div><p>One</p><p>Two</p></div>");
+
+			assert.exception(function() {
+				contentHost.get("p");
+			}, /Expected one element to match 'p', but found 2/);
+		});
+
+		it("retrieves a list of elements", function() {
+			contentHost.add("<div><p id='p1'>One</p><p>Two</p><p>Three</p></div>");
+			var some = contentHost.getAll("p");
+			var named = contentHost.getAll("p", "my name");
+
+			assert.objEqual(some.at(0), contentHost.get("#p1"), "should get a working list");
+			assert.equal(some.toString(), "'p' list", "should describe it by its selector");
+			assert.equal(named.toString(), "'my name' list", "should use nickname when provided");
+        });
+        
+        it("scrolls", function() {
+			contentHost.add("<div style='position: absolute; left: 5000px; top: 5000px; width: 60px'>scroll enabler</div>");
+
+			assert.deepEqual(frame.getRawScrollPosition(), { x: 0, y: 0 }, "should start at (0, 0)");
+
+			contentHost.scroll(150, 300);
+			var position = contentHost.getRawScrollPosition();
+			if (quixote.browser.enlargesFrameToPageSize()) {
+				assert.equal(position.x, 0, "should not have scrolled horizontally because whole page is displayed");
+				assert.equal(position.y, 0, "should not have scrolled vertically because whole page is displayed");
+			}
+			else {
+				assert.equal(position.x, 150, "should have scrolled right");
+				assert.equal(position.y, 300, "should have scrolled down");
+			}
+        });
+
+    });
+
+});

--- a/src/_q_element_list_test.js
+++ b/src/_q_element_list_test.js
@@ -30,9 +30,9 @@ describe("FOUNDATION: QElementList", function() {
 		var oneDom = document.querySelectorAll("ul");
 		var someDom = document.querySelectorAll("li");
 
-		none = new QElementList(noneDom, frame, "none");
-		one = new QElementList(oneDom, frame, "one");
-		some = new QElementList(someDom, frame, "some");
+		none = new QElementList(noneDom, "none");
+		one = new QElementList(oneDom, "one");
+		some = new QElementList(someDom, "some");
 
 		item1 = frame.get("#item1");
 		item2 = frame.get("#item2");

--- a/src/_q_element_test.js
+++ b/src/_q_element_test.js
@@ -39,23 +39,23 @@ describe("FOUNDATION: QElement", function() {
 	describe("object", function() {
 
 		it("compares to another QElement", function() {
-			var head = new QElement(document.querySelector("head"), frame, "head");    // WORKAROUND IE8: no document.head
-			var body1 = new QElement(document.body, frame, "body");
-			var body2 = new QElement(document.body, frame, "body");
+			var head = new QElement(document.querySelector("head"), "head");    // WORKAROUND IE8: no document.head
+			var body1 = new QElement(document.body, "body");
+			var body2 = new QElement(document.body, "body");
 
 			assert.objEqual(body1, body2, "equality");
 			assert.objNotEqual(head, body1, "inequality");
 		});
 
 		it("element description does not affect equality", function() {
-			var body1 = new QElement(document.body, frame, "body description");
-			var body2 = new QElement(document.body, frame, "description can be anything");
+			var body1 = new QElement(document.body, "body description");
+			var body2 = new QElement(document.body, "description can be anything");
 
 			assert.objEqual(body1, body2, "should still be equal");
 		});
 
 		it("converts to string", function() {
-			var element = new QElement(document.body, frame, "nickname");
+			var element = new QElement(document.body, "nickname");
 			assert.equal(element.toString(), "'nickname'");
 		});
 
@@ -64,7 +64,7 @@ describe("FOUNDATION: QElement", function() {
 	describe("DOM manipulation", function() {
 
 		it("converts to DOM element", function() {
-			var q = new QElement(document.body, frame, "body");
+			var q = new QElement(document.body, "body");
 			var dom = q.toDomElement();
 
 			assert.equal(dom, document.body);
@@ -126,11 +126,6 @@ describe("FOUNDATION: QElement", function() {
 	});
 
 	describe("properties", function() {
-
-		it("frame", function() {
-			assert.equal(element.frame, frame);
-		});
-
 		it("visibility", function() {
 			if (quixote.browser.misreportsClipAutoProperty()) return;
 

--- a/src/_q_element_test.js
+++ b/src/_q_element_test.js
@@ -59,6 +59,14 @@ describe("FOUNDATION: QElement", function() {
 			assert.equal(element.toString(), "'nickname'");
 		});
 
+		it("makes a best guess at a description when not given one", function() {
+			var bodyElement = new QElement(document.body);
+			var paragraphElement = new QElement(frame.body().toDomElement().querySelector("p"));
+
+			assert.equal(bodyElement.toString(), "'BODY'");
+			assert.equal(paragraphElement.toString(), "'element'");
+		});
+
 	});
 
 	describe("DOM manipulation", function() {

--- a/src/_q_element_test.js
+++ b/src/_q_element_test.js
@@ -6,6 +6,7 @@ var quixote = require("./quixote.js");
 var reset = require("./__reset.js");
 var shim = require("./util/shim.js");
 var Assertable = require("./assertable.js");
+var QContentHost = require("./q_content_host");
 var QElement = require("./q_element.js");
 
 describe("FOUNDATION: QElement", function() {
@@ -100,6 +101,18 @@ describe("FOUNDATION: QElement", function() {
 		it("parent element of detached element is 'null'", function() {
 			element.remove();
 			assert.equal(element.parent(), null);
+		});
+
+		it("provides access to its host", function() {
+			var body = new QElement(document.body, "body");
+			var contentHost = new QContentHost(document);
+
+			assert.objEqual(body.host(), contentHost);
+		});
+
+		it("host of detached element is still the original host", function() {
+			element.remove();
+			assert.objEqual(element.host(), frame.toContentHost());
 		});
 
 		it("adds child element", function() {

--- a/src/_q_frame_test.js
+++ b/src/_q_frame_test.js
@@ -5,6 +5,7 @@ var assert = require("./util/assert.js");
 var reset = require("./__reset.js");
 var quixote = require("./quixote.js");
 var QFrame = require("./q_frame.js");
+var QContentHost = require("./q_content_host");
 var QElement = require("./q_element.js");
 var QViewport = require("./q_viewport.js");
 var QPage = require("./q_page.js");
@@ -363,73 +364,8 @@ describe("FOUNDATION: QFrame", function() {
 			frameDom = frame.toDomElement();
 		});
 
-		it("provides access to viewport descriptors", function() {
-			assert.type(frame.viewport(), QViewport);
-		});
-
-		it("provides access to page descriptors", function() {
-			assert.type(frame.page(), QPage);
-		});
-
-		it("retrieves body element", function() {
-			assert.objEqual(frame.body(), new QElement(frameDom.contentDocument.body, "body"), "body element");
-			assert.equal(frame.body().toString(), "'body'", "body description");
-		});
-
-		it("adds an element", function() {
-			var element = frame.add("<p>foo</p>");
-			var body = frame.body();
-
-			assert.objEqual(element.parent(), body, "element should be present in frame body");
-			assert.equal(element.toString(), "'<p>foo</p>'", "name should match the HTML created");
-		});
-
-		it("uses optional nickname to describe added elements", function() {
-			var element = frame.add("<p>foo</p>", "my element");
-			assert.equal(element.toString(), "'my element'");
-		});
-
-		it("retrieves an element by selector", function() {
-			var expected = frame.add("<div id='foo' class='bar' baz='boo'>Irrelevant text</div>");
-			var byId = frame.get("#foo");
-			var byClass = frame.get(".bar");
-			var byAttribute = frame.get("[baz]");
-
-			assert.objEqual(byId, expected, "should get element by ID");
-			assert.objEqual(byClass, expected, "should get element by class");
-			assert.objEqual(byAttribute, expected, "should get element by attribute");
-
-			assert.equal(byId.toString(), "'#foo'", "should describe element by selector used");
-		});
-
-		it("uses optional nickname to describe retrieved elements", function() {
-			frame.add("<div id='foo'>Irrelevant text</div>");
-			var element = frame.get("#foo", "Bestest Element Ever!!");
-			assert.equal(element.toString(), "'Bestest Element Ever!!'");
-		});
-
-		it("fails fast when retrieving non-existant element", function() {
-			assert.exception(function() {
-				frame.get(".blah");
-			}, /Expected one element to match '\.blah', but found 0/);
-		});
-
-		it("fails fast when retrieving too many elements", function() {
-			frame.add("<div><p>One</p><p>Two</p></div>");
-
-			assert.exception(function() {
-				frame.get("p");
-			}, /Expected one element to match 'p', but found 2/);
-		});
-
-		it("retrieves a list of elements", function() {
-			frame.add("<div><p id='p1'>One</p><p>Two</p><p>Three</p></div>");
-			var some = frame.getAll("p");
-			var named = frame.getAll("p", "my name");
-
-			assert.objEqual(some.at(0), frame.get("#p1"), "should get a working list");
-			assert.equal(some.toString(), "'p' list", "should describe it by its selector");
-			assert.equal(named.toString(), "'my name' list", "should use nickname when provided");
+		it("provides access to contentHost", function() {
+			assert.type(frame.toContentHost(), QContentHost);
 		});
 
 		it("resets frame without src document", function() {
@@ -439,21 +375,10 @@ describe("FOUNDATION: QFrame", function() {
 			assert.equal(frameDom.contentDocument.body.innerHTML, "", "frame body");
 		});
 
-		it("scrolls", function() {
+		it("after reset, scroll position also resets", function() {
 			frame.add("<div style='position: absolute; left: 5000px; top: 5000px; width: 60px'>scroll enabler</div>");
 
-			assert.deepEqual(frame.getRawScrollPosition(), { x: 0, y: 0 }, "should start at (0, 0)");
-
 			frame.scroll(150, 300);
-			var position = frame.getRawScrollPosition();
-			if (quixote.browser.enlargesFrameToPageSize()) {
-				assert.equal(position.x, 0, "should not have scrolled horizontally because whole page is displayed");
-				assert.equal(position.y, 0, "should not have scrolled vertically because whole page is displayed");
-			}
-			else {
-				assert.equal(position.x, 150, "should have scrolled right");
-				assert.equal(position.y, 300, "should have scrolled down");
-			}
 
 			frame.reset();
 			assert.equal(frame.getRawScrollPosition().x, 0, "should have reset X scroll position");

--- a/src/_q_frame_test.js
+++ b/src/_q_frame_test.js
@@ -372,7 +372,7 @@ describe("FOUNDATION: QFrame", function() {
 		});
 
 		it("retrieves body element", function() {
-			assert.objEqual(frame.body(), new QElement(frameDom.contentDocument.body, frame, "body"), "body element");
+			assert.objEqual(frame.body(), new QElement(frameDom.contentDocument.body, "body"), "body element");
 			assert.equal(frame.body().toString(), "'body'", "body description");
 		});
 

--- a/src/_q_page_test.js
+++ b/src/_q_page_test.js
@@ -16,7 +16,7 @@ describe("FOUNDATION: QPage", function() {
 
 	beforeEach(function() {
 		frame = reset.frame;
-		page = new QPage(frame.toContent());
+		page = new QPage(frame.toContentHost());
 
 		frame.add(
 			"<div style='position: absolute; left: " + (WIDTH - 100) + "px; top: " + (HEIGHT - 100) + "px; " +

--- a/src/_q_page_test.js
+++ b/src/_q_page_test.js
@@ -16,7 +16,7 @@ describe("FOUNDATION: QPage", function() {
 
 	beforeEach(function() {
 		frame = reset.frame;
-		page = new QPage(frame.toDomElement().contentDocument);
+		page = new QPage(frame.toContent());
 
 		frame.add(
 			"<div style='position: absolute; left: " + (WIDTH - 100) + "px; top: " + (HEIGHT - 100) + "px; " +

--- a/src/_q_page_test.js
+++ b/src/_q_page_test.js
@@ -16,7 +16,7 @@ describe("FOUNDATION: QPage", function() {
 
 	beforeEach(function() {
 		frame = reset.frame;
-		page = new QPage(frame);
+		page = new QPage(frame.toDomElement().contentDocument);
 
 		frame.add(
 			"<div style='position: absolute; left: " + (WIDTH - 100) + "px; top: " + (HEIGHT - 100) + "px; " +

--- a/src/_q_viewport_test.js
+++ b/src/_q_viewport_test.js
@@ -13,7 +13,7 @@ describe("FOUNDATION: QViewport", function() {
 
 	beforeEach(function() {
 		frame = reset.frame;
-		viewport = new QViewport(frame.toContent());
+		viewport = new QViewport(frame.toContentHost());
 	});
 
 	it("is Assertable", function() {

--- a/src/_q_viewport_test.js
+++ b/src/_q_viewport_test.js
@@ -13,7 +13,7 @@ describe("FOUNDATION: QViewport", function() {
 
 	beforeEach(function() {
 		frame = reset.frame;
-		viewport = new QViewport(frame);
+		viewport = new QViewport(frame.toContent());
 	});
 
 	it("is Assertable", function() {

--- a/src/descriptors/_page_edge_test.js
+++ b/src/descriptors/_page_edge_test.js
@@ -19,12 +19,12 @@ describe("DESCRIPTOR: PageEdge", function() {
 
 		beforeEach(function() {
 			var frame = reset.frame;
-			var contentDocument = frame.toDomElement().contentDocument;
+			var content = frame.toContent();
 
-			top = PageEdge.top(contentDocument);
-			right = PageEdge.right(contentDocument);
-			bottom = PageEdge.bottom(contentDocument);
-			left = PageEdge.left(contentDocument);
+			top = PageEdge.top(content);
+			right = PageEdge.right(content);
+			bottom = PageEdge.bottom(content);
+			left = PageEdge.left(content);
 
 			frame.add(
 				"<div style='position: absolute; left: " + (reset.WIDTH + 100) + "px; top: " + (reset.HEIGHT + 100) + "px; " +
@@ -82,8 +82,8 @@ describe("DESCRIPTOR: PageEdge", function() {
 		beforeEach(function() {
 			frame = reset.frame;
 			var contentDocument = frame.toDomElement().contentDocument;
-			right = PageEdge.right(contentDocument);
-			bottom = PageEdge.bottom(contentDocument);
+			right = PageEdge.right(frame.toContent());
+			bottom = PageEdge.bottom(frame.toContent());
 
 			htmlStyle = contentDocument.documentElement.style;
 			htmlStyle.borderLeft = "solid " + HTML_BORDER_LEFT + "px green";

--- a/src/descriptors/_page_edge_test.js
+++ b/src/descriptors/_page_edge_test.js
@@ -19,12 +19,12 @@ describe("DESCRIPTOR: PageEdge", function() {
 
 		beforeEach(function() {
 			var frame = reset.frame;
-			var content = frame.toContent();
+			var contentHost = frame.toContentHost();
 
-			top = PageEdge.top(content);
-			right = PageEdge.right(content);
-			bottom = PageEdge.bottom(content);
-			left = PageEdge.left(content);
+			top = PageEdge.top(contentHost);
+			right = PageEdge.right(contentHost);
+			bottom = PageEdge.bottom(contentHost);
+			left = PageEdge.left(contentHost);
 
 			frame.add(
 				"<div style='position: absolute; left: " + (reset.WIDTH + 100) + "px; top: " + (reset.HEIGHT + 100) + "px; " +
@@ -82,8 +82,8 @@ describe("DESCRIPTOR: PageEdge", function() {
 		beforeEach(function() {
 			frame = reset.frame;
 			var contentDocument = frame.toDomElement().contentDocument;
-			right = PageEdge.right(frame.toContent());
-			bottom = PageEdge.bottom(frame.toContent());
+			right = PageEdge.right(frame.toContentHost());
+			bottom = PageEdge.bottom(frame.toContentHost());
 
 			htmlStyle = contentDocument.documentElement.style;
 			htmlStyle.borderLeft = "solid " + HTML_BORDER_LEFT + "px green";

--- a/src/descriptors/_page_edge_test.js
+++ b/src/descriptors/_page_edge_test.js
@@ -19,11 +19,12 @@ describe("DESCRIPTOR: PageEdge", function() {
 
 		beforeEach(function() {
 			var frame = reset.frame;
+			var contentDocument = frame.toDomElement().contentDocument;
 
-			top = PageEdge.top(frame);
-			right = PageEdge.right(frame);
-			bottom = PageEdge.bottom(frame);
-			left = PageEdge.left(frame);
+			top = PageEdge.top(contentDocument);
+			right = PageEdge.right(contentDocument);
+			bottom = PageEdge.bottom(contentDocument);
+			left = PageEdge.left(contentDocument);
 
 			frame.add(
 				"<div style='position: absolute; left: " + (reset.WIDTH + 100) + "px; top: " + (reset.HEIGHT + 100) + "px; " +
@@ -80,10 +81,10 @@ describe("DESCRIPTOR: PageEdge", function() {
 
 		beforeEach(function() {
 			frame = reset.frame;
-			right = PageEdge.right(frame);
-			bottom = PageEdge.bottom(frame);
-
 			var contentDocument = frame.toDomElement().contentDocument;
+			right = PageEdge.right(contentDocument);
+			bottom = PageEdge.bottom(contentDocument);
+
 			htmlStyle = contentDocument.documentElement.style;
 			htmlStyle.borderLeft = "solid " + HTML_BORDER_LEFT + "px green";
 			htmlStyle.borderRight = "solid " + HTML_BORDER_RIGHT + "px green";

--- a/src/descriptors/_viewport_edge_test.js
+++ b/src/descriptors/_viewport_edge_test.js
@@ -23,10 +23,10 @@ describe("DESCRIPTOR: ViewportEdge", function() {
 	beforeEach(function() {
 		frame = reset.frame;
 
-		top = ViewportEdge.top(frame.toContent());
-		right = ViewportEdge.right(frame.toContent());
-		bottom = ViewportEdge.bottom(frame.toContent());
-		left = ViewportEdge.left(frame.toContent());
+		top = ViewportEdge.top(frame.toContentHost());
+		right = ViewportEdge.right(frame.toContentHost());
+		bottom = ViewportEdge.bottom(frame.toContentHost());
+		left = ViewportEdge.left(frame.toContentHost());
 	});
 
 	it("is a position descriptor", function() {
@@ -113,8 +113,8 @@ describe("DESCRIPTOR: ViewportEdge", function() {
 
 		beforeEach(function() {
 			contentDoc = frame.toDomElement().contentDocument;
-			right = ViewportEdge.right(frame.toContent());
-			bottom = ViewportEdge.bottom(frame.toContent());
+			right = ViewportEdge.right(frame.toContentHost());
+			bottom = ViewportEdge.bottom(frame.toContentHost());
 
 			contentDoc.body.style.backgroundColor = "blue";
 		});

--- a/src/descriptors/_viewport_edge_test.js
+++ b/src/descriptors/_viewport_edge_test.js
@@ -23,10 +23,10 @@ describe("DESCRIPTOR: ViewportEdge", function() {
 	beforeEach(function() {
 		frame = reset.frame;
 
-		top = ViewportEdge.top(frame);
-		right = ViewportEdge.right(frame);
-		bottom = ViewportEdge.bottom(frame);
-		left = ViewportEdge.left(frame);
+		top = ViewportEdge.top(frame.toContent());
+		right = ViewportEdge.right(frame.toContent());
+		bottom = ViewportEdge.bottom(frame.toContent());
+		left = ViewportEdge.left(frame.toContent());
 	});
 
 	it("is a position descriptor", function() {
@@ -113,8 +113,8 @@ describe("DESCRIPTOR: ViewportEdge", function() {
 
 		beforeEach(function() {
 			contentDoc = frame.toDomElement().contentDocument;
-			right = ViewportEdge.right(frame);
-			bottom = ViewportEdge.bottom(frame);
+			right = ViewportEdge.right(frame.toContent());
+			bottom = ViewportEdge.bottom(frame.toContent());
 
 			contentDoc.body.style.backgroundColor = "blue";
 		});

--- a/src/descriptors/element_edge.js
+++ b/src/descriptors/element_edge.js
@@ -38,11 +38,11 @@ Me.prototype.value = function value() {
 	var scroll = this._element.parentContent().getRawScrollPosition();
 
 	if (this._position === RIGHT || this._position === LEFT) {
-		if (!elementRendered(this, rawPosition)) return Position.noX();
+		if (!this._element.parentContent().elementRendered(this._element)) return Position.noX();
 		return Position.x(edge + scroll.x);
 	}
 	else {
-		if (!elementRendered(this, rawPosition)) return Position.noY();
+		if (!this._element.parentContent().elementRendered(this._element)) return Position.noY();
 		return Position.y(edge + scroll.y);
 	}
 };
@@ -56,13 +56,4 @@ function factoryFn(position) {
 	return function factory(element) {
 		return new Me(element, position);
 	};
-}
-
-function elementRendered(self, rawPosition) {
-	var element = self._element;
-
-	var inDom = element.parentDocument().body.contains(element.toDomElement());
-	var displayNone = element.getRawStyle("display") === "none";
-
-	return inDom && !displayNone;
 }

--- a/src/descriptors/element_edge.js
+++ b/src/descriptors/element_edge.js
@@ -4,6 +4,7 @@
 var ensure = require("../util/ensure.js");
 var Position = require("../values/position.js");
 var PositionDescriptor = require("./position_descriptor.js");
+var shim = require("../util/shim.js");
 
 var TOP = "top";
 var RIGHT = "right";
@@ -34,7 +35,7 @@ Me.prototype.value = function value() {
 	var rawPosition = this._element.getRawPosition();
 
 	var edge = rawPosition[this._position];
-	var scroll = this._element.frame.getRawScrollPosition();
+	var scroll = getRawScrollPosition(this);
 
 	if (this._position === RIGHT || this._position === LEFT) {
 		if (!elementRendered(this, rawPosition)) return Position.noX();
@@ -60,8 +61,15 @@ function factoryFn(position) {
 function elementRendered(self, rawPosition) {
 	var element = self._element;
 
-	var inDom = element.frame.body().toDomElement().contains(element.toDomElement());
+	var inDom = element.parentDocument().body.contains(element.toDomElement());
 	var displayNone = element.getRawStyle("display") === "none";
 
 	return inDom && !displayNone;
+}
+
+function getRawScrollPosition(self) {
+	return {
+		x: shim.Window.pageXOffset(self._element.parentWindow(), self._element.parentDocument()),
+		y: shim.Window.pageYOffset(self._element.parentWindow(), self._element.parentDocument())
+	};
 }

--- a/src/descriptors/element_edge.js
+++ b/src/descriptors/element_edge.js
@@ -35,14 +35,14 @@ Me.prototype.value = function value() {
 	var rawPosition = this._element.getRawPosition();
 
 	var edge = rawPosition[this._position];
-	var scroll = this._element.parentContentHost().getRawScrollPosition();
+	var scroll = this._element.host().getRawScrollPosition();
 
 	if (this._position === RIGHT || this._position === LEFT) {
-		if (!this._element.parentContentHost().elementRendered(this._element)) return Position.noX();
+		if (!this._element.host().elementRendered(this._element)) return Position.noX();
 		return Position.x(edge + scroll.x);
 	}
 	else {
-		if (!this._element.parentContentHost().elementRendered(this._element)) return Position.noY();
+		if (!this._element.host().elementRendered(this._element)) return Position.noY();
 		return Position.y(edge + scroll.y);
 	}
 };

--- a/src/descriptors/element_edge.js
+++ b/src/descriptors/element_edge.js
@@ -35,7 +35,7 @@ Me.prototype.value = function value() {
 	var rawPosition = this._element.getRawPosition();
 
 	var edge = rawPosition[this._position];
-	var scroll = getRawScrollPosition(this);
+	var scroll = this._element.parentContent().getRawScrollPosition();
 
 	if (this._position === RIGHT || this._position === LEFT) {
 		if (!elementRendered(this, rawPosition)) return Position.noX();
@@ -65,11 +65,4 @@ function elementRendered(self, rawPosition) {
 	var displayNone = element.getRawStyle("display") === "none";
 
 	return inDom && !displayNone;
-}
-
-function getRawScrollPosition(self) {
-	return {
-		x: shim.Window.pageXOffset(self._element.parentWindow(), self._element.parentDocument()),
-		y: shim.Window.pageYOffset(self._element.parentWindow(), self._element.parentDocument())
-	};
 }

--- a/src/descriptors/element_edge.js
+++ b/src/descriptors/element_edge.js
@@ -35,14 +35,14 @@ Me.prototype.value = function value() {
 	var rawPosition = this._element.getRawPosition();
 
 	var edge = rawPosition[this._position];
-	var scroll = this._element.parentContent().getRawScrollPosition();
+	var scroll = this._element.parentContentHost().getRawScrollPosition();
 
 	if (this._position === RIGHT || this._position === LEFT) {
-		if (!this._element.parentContent().elementRendered(this._element)) return Position.noX();
+		if (!this._element.parentContentHost().elementRendered(this._element)) return Position.noX();
 		return Position.x(edge + scroll.x);
 	}
 	else {
-		if (!this._element.parentContent().elementRendered(this._element)) return Position.noY();
+		if (!this._element.parentContentHost().elementRendered(this._element)) return Position.noY();
 		return Position.y(edge + scroll.y);
 	}
 };

--- a/src/descriptors/element_rendered_edge.js
+++ b/src/descriptors/element_rendered_edge.js
@@ -5,6 +5,7 @@ var ensure = require("../util/ensure.js");
 var quixote = require("../quixote.js");
 var PositionDescriptor = require("./position_descriptor.js");
 var Position = require("../values/position.js");
+var QPage = require("../q_page.js");
 var Size = require("../values/size.js");
 var RenderState = require("../values/render_state.js");
 
@@ -45,7 +46,7 @@ Me.prototype.toString = function toString() {
 Me.prototype.value = function() {
 	var position = this._position;
 	var element = this._element;
-	var page = element.frame.page();
+	var page = new QPage(this._element.parentDocument());
 
 	if (element.top.value().equals(Position.noY())) return notRendered(position);
 	if (element.width.value().equals(Size.create(0))) return notRendered(position);

--- a/src/descriptors/element_rendered_edge.js
+++ b/src/descriptors/element_rendered_edge.js
@@ -46,7 +46,7 @@ Me.prototype.toString = function toString() {
 Me.prototype.value = function() {
 	var position = this._position;
 	var element = this._element;
-	var page = new QPage(this._element.parentContent());
+	var page = new QPage(this._element.parentContentHost());
 
 	if (element.top.value().equals(Position.noY())) return notRendered(position);
 	if (element.width.value().equals(Size.create(0))) return notRendered(position);

--- a/src/descriptors/element_rendered_edge.js
+++ b/src/descriptors/element_rendered_edge.js
@@ -46,7 +46,7 @@ Me.prototype.toString = function toString() {
 Me.prototype.value = function() {
 	var position = this._position;
 	var element = this._element;
-	var page = new QPage(this._element.parentContentHost());
+	var page = new QPage(this._element.host());
 
 	if (element.top.value().equals(Position.noY())) return notRendered(position);
 	if (element.width.value().equals(Size.create(0))) return notRendered(position);

--- a/src/descriptors/element_rendered_edge.js
+++ b/src/descriptors/element_rendered_edge.js
@@ -46,7 +46,7 @@ Me.prototype.toString = function toString() {
 Me.prototype.value = function() {
 	var position = this._position;
 	var element = this._element;
-	var page = new QPage(this._element.parentDocument());
+	var page = new QPage(this._element.parentContent());
 
 	if (element.top.value().equals(Position.noY())) return notRendered(position);
 	if (element.width.value().equals(Size.create(0))) return notRendered(position);

--- a/src/descriptors/page_edge.js
+++ b/src/descriptors/page_edge.js
@@ -4,22 +4,22 @@
 var ensure = require("../util/ensure.js");
 var PositionDescriptor = require("./position_descriptor.js");
 var Position = require("../values/position.js");
-var QContent = require("../q_content.js");
+var QContentHost = require("../q_content_host.js");
 
 var TOP = "top";
 var RIGHT = "right";
 var BOTTOM = "bottom";
 var LEFT = "left";
 
-var Me = module.exports = function PageEdge(edge, content) {
-	ensure.signature(arguments, [ String, QContent ]);
+var Me = module.exports = function PageEdge(edge, contentHost) {
+	ensure.signature(arguments, [ String, QContentHost ]);
 
 	if (edge === LEFT || edge === RIGHT) PositionDescriptor.x(this);
 	else if (edge === TOP || edge === BOTTOM) PositionDescriptor.y(this);
 	else ensure.unreachable("Unknown edge: " + edge);
 
 	this._edge = edge;
-	this._content = content;
+	this._contentHost = contentHost;
 };
 PositionDescriptor.extend(Me);
 
@@ -31,7 +31,7 @@ Me.left = factoryFn(LEFT);
 Me.prototype.value = function value() {
 	ensure.signature(arguments, []);
 
-	var size = pageSize(this._content.toDomElement().document);
+	var size = pageSize(this._contentHost.toDomElement().document);
 	switch(this._edge) {
 		case TOP: return Position.y(0);
 		case RIGHT: return Position.x(size.width);

--- a/src/descriptors/page_edge.js
+++ b/src/descriptors/page_edge.js
@@ -31,7 +31,7 @@ Me.left = factoryFn(LEFT);
 Me.prototype.value = function value() {
 	ensure.signature(arguments, []);
 
-	var size = pageSize(this._content.document);
+	var size = pageSize(this._content.toDomElement().document);
 	switch(this._edge) {
 		case TOP: return Position.y(0);
 		case RIGHT: return Position.x(size.width);

--- a/src/descriptors/page_edge.js
+++ b/src/descriptors/page_edge.js
@@ -4,24 +4,22 @@
 var ensure = require("../util/ensure.js");
 var PositionDescriptor = require("./position_descriptor.js");
 var Position = require("../values/position.js");
+var QContent = require("../q_content.js");
 
 var TOP = "top";
 var RIGHT = "right";
 var BOTTOM = "bottom";
 var LEFT = "left";
 
-var Me = module.exports = function PageEdge(edge, contentDocument) {
-	// Cannot check against HTMLDocument directly because most browsers define HTMLDocument on the Window type
-	// Since the document is in an iFrame its HTMLDocument definition is the iFrame window's HTMLDocument and
-	// not the top level window's version.
-	ensure.signature(arguments, [ String, Object ]);
+var Me = module.exports = function PageEdge(edge, content) {
+	ensure.signature(arguments, [ String, QContent ]);
 
 	if (edge === LEFT || edge === RIGHT) PositionDescriptor.x(this);
 	else if (edge === TOP || edge === BOTTOM) PositionDescriptor.y(this);
 	else ensure.unreachable("Unknown edge: " + edge);
 
 	this._edge = edge;
-	this._document = contentDocument;
+	this._content = content;
 };
 PositionDescriptor.extend(Me);
 
@@ -33,7 +31,7 @@ Me.left = factoryFn(LEFT);
 Me.prototype.value = function value() {
 	ensure.signature(arguments, []);
 
-	var size = pageSize(this._document);
+	var size = pageSize(this._content.document);
 	switch(this._edge) {
 		case TOP: return Position.y(0);
 		case RIGHT: return Position.x(size.width);
@@ -58,8 +56,8 @@ Me.prototype.toString = function toString() {
 };
 
 function factoryFn(edge) {
-	return function factory(contentDocument) {
-		return new Me(edge, contentDocument);
+	return function factory(content) {
+		return new Me(edge, content);
 	};
 }
 

--- a/src/descriptors/page_edge.js
+++ b/src/descriptors/page_edge.js
@@ -10,16 +10,18 @@ var RIGHT = "right";
 var BOTTOM = "bottom";
 var LEFT = "left";
 
-var Me = module.exports = function PageEdge(edge, frame) {
-	var QFrame = require("../q_frame.js");    // break circular dependency
-	ensure.signature(arguments, [ String, QFrame ]);
+var Me = module.exports = function PageEdge(edge, contentDocument) {
+	// Cannot check against HTMLDocument directly because most browsers define HTMLDocument on the Window type
+	// Since the document is in an iFrame its HTMLDocument definition is the iFrame window's HTMLDocument and
+	// not the top level window's version.
+	ensure.signature(arguments, [ String, Object ]);
 
 	if (edge === LEFT || edge === RIGHT) PositionDescriptor.x(this);
 	else if (edge === TOP || edge === BOTTOM) PositionDescriptor.y(this);
 	else ensure.unreachable("Unknown edge: " + edge);
 
 	this._edge = edge;
-	this._frame = frame;
+	this._document = contentDocument;
 };
 PositionDescriptor.extend(Me);
 
@@ -31,7 +33,7 @@ Me.left = factoryFn(LEFT);
 Me.prototype.value = function value() {
 	ensure.signature(arguments, []);
 
-	var size = pageSize(this._frame.toDomElement().contentDocument);
+	var size = pageSize(this._document);
 	switch(this._edge) {
 		case TOP: return Position.y(0);
 		case RIGHT: return Position.x(size.width);
@@ -56,8 +58,8 @@ Me.prototype.toString = function toString() {
 };
 
 function factoryFn(edge) {
-	return function factory(frame) {
-		return new Me(edge, frame);
+	return function factory(contentDocument) {
+		return new Me(edge, contentDocument);
 	};
 }
 

--- a/src/descriptors/page_edge.js
+++ b/src/descriptors/page_edge.js
@@ -31,7 +31,7 @@ Me.left = factoryFn(LEFT);
 Me.prototype.value = function value() {
 	ensure.signature(arguments, []);
 
-	var size = pageSize(this._contentHost.toDomElement().document);
+	var size = pageSize(this._contentHost.document);
 	switch(this._edge) {
 		case TOP: return Position.y(0);
 		case RIGHT: return Position.x(size.width);

--- a/src/descriptors/viewport_edge.js
+++ b/src/descriptors/viewport_edge.js
@@ -4,22 +4,22 @@
 var ensure = require("../util/ensure.js");
 var PositionDescriptor = require("./position_descriptor.js");
 var Position = require("../values/position.js");
-var QContent = require("../q_content.js");
+var QContentHost = require("../q_content_host.js");
 
 var TOP = "top";
 var RIGHT = "right";
 var BOTTOM = "bottom";
 var LEFT = "left";
 
-var Me = module.exports = function ViewportEdge(position, content) {
-	ensure.signature(arguments, [ String, QContent ]);
+var Me = module.exports = function ViewportEdge(position, contentHost) {
+	ensure.signature(arguments, [ String, QContentHost ]);
 
 	if (position === LEFT || position === RIGHT) PositionDescriptor.x(this);
 	else if (position === TOP || position === BOTTOM) PositionDescriptor.y(this);
 	else ensure.unreachable("Unknown position: " + position);
 
 	this._position = position;
-	this._content = content;
+	this._contentHost = contentHost;
 };
 PositionDescriptor.extend(Me);
 
@@ -31,11 +31,11 @@ Me.left = factoryFn(LEFT);
 Me.prototype.value = function() {
 	ensure.signature(arguments, []);
 
-	var scroll = this._content.getRawScrollPosition();
+	var scroll = this._contentHost.getRawScrollPosition();
 	var x = Position.x(scroll.x);
 	var y = Position.y(scroll.y);
 
-	var size = viewportSize(this._content.toDomElement().document.documentElement);
+	var size = viewportSize(this._contentHost.toDomElement().document.documentElement);
 
 	switch(this._position) {
 		case TOP: return y;

--- a/src/descriptors/viewport_edge.js
+++ b/src/descriptors/viewport_edge.js
@@ -4,22 +4,22 @@
 var ensure = require("../util/ensure.js");
 var PositionDescriptor = require("./position_descriptor.js");
 var Position = require("../values/position.js");
+var QContent = require("../q_content.js");
 
 var TOP = "top";
 var RIGHT = "right";
 var BOTTOM = "bottom";
 var LEFT = "left";
 
-var Me = module.exports = function ViewportEdge(position, frame) {
-	var QFrame = require("../q_frame.js");    // break circular dependency
-	ensure.signature(arguments, [ String, QFrame ]);
+var Me = module.exports = function ViewportEdge(position, content) {
+	ensure.signature(arguments, [ String, QContent ]);
 
 	if (position === LEFT || position === RIGHT) PositionDescriptor.x(this);
 	else if (position === TOP || position === BOTTOM) PositionDescriptor.y(this);
 	else ensure.unreachable("Unknown position: " + position);
 
 	this._position = position;
-	this._frame = frame;
+	this._content = content;
 };
 PositionDescriptor.extend(Me);
 
@@ -31,11 +31,11 @@ Me.left = factoryFn(LEFT);
 Me.prototype.value = function() {
 	ensure.signature(arguments, []);
 
-	var scroll = this._frame.getRawScrollPosition();
+	var scroll = this._content.getRawScrollPosition();
 	var x = Position.x(scroll.x);
 	var y = Position.y(scroll.y);
 
-	var size = viewportSize(this._frame.get("html").toDomElement());
+	var size = viewportSize(this._content.toDomElement().document.documentElement);
 
 	switch(this._position) {
 		case TOP: return y;
@@ -53,8 +53,8 @@ Me.prototype.toString = function() {
 };
 
 function factoryFn(position) {
-	return function factory(frame) {
-		return new Me(position, frame);
+	return function factory(content) {
+		return new Me(position, content);
 	};
 }
 

--- a/src/descriptors/viewport_edge.js
+++ b/src/descriptors/viewport_edge.js
@@ -35,7 +35,7 @@ Me.prototype.value = function() {
 	var x = Position.x(scroll.x);
 	var y = Position.y(scroll.y);
 
-	var size = viewportSize(this._contentHost.toDomElement().document.documentElement);
+	var size = viewportSize(this._contentHost.document.documentElement);
 
 	switch(this._position) {
 		case TOP: return y;

--- a/src/q_content.js
+++ b/src/q_content.js
@@ -15,6 +15,12 @@ var Me = module.exports = function QContent(contentDocument) {
     this.window = contentDocument.defaultView || contentDocument.parentWindow;
 };
 
+Me.prototype.toDomElement = function toDomElement() {
+    ensure.signature(arguments, []);
+
+    return this.window;
+};
+
 Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
     ensure.signature(arguments, []);
 

--- a/src/q_content.js
+++ b/src/q_content.js
@@ -16,6 +16,8 @@ var Me = module.exports = function QContent(contentDocument) {
 };
 
 Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
+    ensure.signature(arguments, []);
+
 	return {
 		x: shim.Window.pageXOffset(this.window, this.document),
 		y: shim.Window.pageYOffset(this.window, this.document)
@@ -30,4 +32,11 @@ Me.prototype.elementRendered = function elementRendered(element) {
 	var displayNone = element.getRawStyle("display") === "none";
 
 	return inDom && !displayNone;
+};
+
+Me.prototype.getComputedStyle = function getComputedStyle(element) {
+    var QElement = require("./q_element.js");      // break circular dependency
+    ensure.signature(arguments, [ QElement ]);
+
+	return this.window.getComputedStyle(element.toDomElement());
 };

--- a/src/q_content.js
+++ b/src/q_content.js
@@ -1,0 +1,15 @@
+// Copyright (c) 2014-2017 Titanium I.T. LLC. All rights reserved. For license, see "README" or "LICENSE" file.
+"use strict";
+
+var ensure = require("./util/ensure.js");
+
+var Me = module.exports = function QContent(contentDocument) {
+	// Cannot check against HTMLDocument directly because most browsers define HTMLDocument on the Window type
+	// Since the document is in an iFrame its HTMLDocument definition is the iFrame window's HTMLDocument and
+	// not the top level window's version.
+	ensure.signature(arguments, [ Object ]);
+
+	// properties
+    this.document = contentDocument;
+    this.window = contentDocument.defaultView || contentDocument.parentWindow;
+};

--- a/src/q_content.js
+++ b/src/q_content.js
@@ -21,3 +21,13 @@ Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
 		y: shim.Window.pageYOffset(this.window, this.document)
 	};
 };
+
+Me.prototype.elementRendered = function elementRendered(element) {
+    var QElement = require("./q_element.js");      // break circular dependency
+    ensure.signature(arguments, [ QElement ]);
+
+	var inDom = this.document.body.contains(element.toDomElement());
+	var displayNone = element.getRawStyle("display") === "none";
+
+	return inDom && !displayNone;
+};

--- a/src/q_content.js
+++ b/src/q_content.js
@@ -10,23 +10,24 @@ var Me = module.exports = function QContent(contentDocument) {
 	// not the top level window's version.
 	ensure.signature(arguments, [ Object ]);
 
+    this._window = contentDocument.defaultView || contentDocument.parentWindow;
+
 	// properties
     this.document = contentDocument;
-    this.window = contentDocument.defaultView || contentDocument.parentWindow;
 };
 
 Me.prototype.toDomElement = function toDomElement() {
     ensure.signature(arguments, []);
 
-    return this.window;
+    return this._window;
 };
 
 Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
     ensure.signature(arguments, []);
 
 	return {
-		x: shim.Window.pageXOffset(this.window, this.document),
-		y: shim.Window.pageYOffset(this.window, this.document)
+		x: shim.Window.pageXOffset(this._window, this.document),
+		y: shim.Window.pageYOffset(this._window, this.document)
 	};
 };
 
@@ -44,5 +45,5 @@ Me.prototype.getComputedStyle = function getComputedStyle(element) {
     var QElement = require("./q_element.js");      // break circular dependency
     ensure.signature(arguments, [ QElement ]);
 
-	return this.window.getComputedStyle(element.toDomElement());
+	return this._window.getComputedStyle(element.toDomElement());
 };

--- a/src/q_content.js
+++ b/src/q_content.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var ensure = require("./util/ensure.js");
+var shim = require("./util/shim.js");
 
 var Me = module.exports = function QContent(contentDocument) {
 	// Cannot check against HTMLDocument directly because most browsers define HTMLDocument on the Window type
@@ -12,4 +13,11 @@ var Me = module.exports = function QContent(contentDocument) {
 	// properties
     this.document = contentDocument;
     this.window = contentDocument.defaultView || contentDocument.parentWindow;
+};
+
+Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
+	return {
+		x: shim.Window.pageXOffset(this.window, this.document),
+		y: shim.Window.pageYOffset(this.window, this.document)
+	};
 };

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -47,3 +47,8 @@ Me.prototype.getComputedStyle = function getComputedStyle(element) {
 
 	return this._window.getComputedStyle(element.toDomElement());
 };
+
+Me.prototype.body = function body() {
+	var QElement = require("./q_element.js");      // break circular dependency
+	return new QElement(this.document.body, "body");
+};

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -110,3 +110,18 @@ Me.prototype.addStylesheetLink = function addStylesheetLink(url, onStylesheetLoa
 	link.setAttribute("href", url);
 	shim.Document.head(this.document).appendChild(link);
 };
+
+Me.prototype.addRawStylesheet = function addRawStylesheet(rawCSS) {
+	ensure.signature(arguments, [String]);
+
+	var style = this.document.createElement("style");
+	style.setAttribute("type", "text/css");
+	if (style.styleSheet) {
+		// WORKAROUND IE 8: Throws 'unknown runtime error' if you set innerHTML on a <style> tag
+		style.styleSheet.cssText = rawCSS;
+	}
+	else {
+		style.innerHTML = rawCSS;
+	}
+	shim.Document.head(this.document).appendChild(style);
+};

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -12,7 +12,7 @@ var Me = module.exports = function QContentHost(contentDocument) {
 
 	this._window = contentDocument.defaultView || contentDocument.parentWindow;
 
-	// public properties
+	// internal properties
 	this.document = contentDocument;
 };
 
@@ -20,23 +20,6 @@ Me.prototype.toDomElement = function toDomElement() {
     ensure.signature(arguments, []);
 
     return this._window;
-};
-
-Me.prototype.elementRendered = function elementRendered(element) {
-    var QElement = require("./q_element.js");      // break circular dependency
-    ensure.signature(arguments, [ QElement ]);
-
-	var inDom = this.document.body.contains(element.toDomElement());
-	var displayNone = element.getRawStyle("display") === "none";
-
-	return inDom && !displayNone;
-};
-
-Me.prototype.getComputedStyle = function getComputedStyle(element) {
-    var QElement = require("./q_element.js");      // break circular dependency
-    ensure.signature(arguments, [ QElement ]);
-
-	return this._window.getComputedStyle(element.toDomElement());
 };
 
 Me.prototype.body = function body() {
@@ -100,6 +83,26 @@ Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
 	};
 };
 
+// internal
+Me.prototype.elementRendered = function elementRendered(element) {
+    var QElement = require("./q_element.js");      // break circular dependency
+    ensure.signature(arguments, [ QElement ]);
+
+	var inDom = this.document.body.contains(element.toDomElement());
+	var displayNone = element.getRawStyle("display") === "none";
+
+	return inDom && !displayNone;
+};
+
+// internal
+Me.prototype.getComputedStyle = function getComputedStyle(element) {
+    var QElement = require("./q_element.js");      // break circular dependency
+    ensure.signature(arguments, [ QElement ]);
+
+	return this._window.getComputedStyle(element.toDomElement());
+};
+
+// internal
 Me.prototype.addStylesheetLink = function addStylesheetLink(url, onStylesheetLoad) {
 	ensure.signature(arguments, [String, Function]);
 
@@ -111,6 +114,7 @@ Me.prototype.addStylesheetLink = function addStylesheetLink(url, onStylesheetLoa
 	shim.Document.head(this.document).appendChild(link);
 };
 
+// internal
 Me.prototype.addRawStylesheet = function addRawStylesheet(rawCSS) {
 	ensure.signature(arguments, [String]);
 
@@ -124,4 +128,10 @@ Me.prototype.addRawStylesheet = function addRawStylesheet(rawCSS) {
 		style.innerHTML = rawCSS;
 	}
 	shim.Document.head(this.document).appendChild(style);
+};
+
+// internal
+Me.prototype.equals = function equals(that) {
+	ensure.signature(arguments, [Me]);
+	return this._window === that._window;
 };

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -10,10 +10,8 @@ var Me = module.exports = function QContentHost(contentDocument) {
 	// not the top level window's version.
 	ensure.signature(arguments, [ Object ]);
 
-    this._window = contentDocument.defaultView || contentDocument.parentWindow;
-
-	// properties
-    this.document = contentDocument;
+	this._document = contentDocument;
+	this._window = contentDocument.defaultView || contentDocument.parentWindow;
 };
 
 Me.prototype.toDomElement = function toDomElement() {
@@ -26,7 +24,7 @@ Me.prototype.elementRendered = function elementRendered(element) {
     var QElement = require("./q_element.js");      // break circular dependency
     ensure.signature(arguments, [ QElement ]);
 
-	var inDom = this.document.body.contains(element.toDomElement());
+	var inDom = this._document.body.contains(element.toDomElement());
 	var displayNone = element.getRawStyle("display") === "none";
 
 	return inDom && !displayNone;
@@ -43,7 +41,7 @@ Me.prototype.body = function body() {
 	var QElement = require("./q_element.js");      // break circular dependency
 	ensure.signature(arguments, []);
 
-	return new QElement(this.document.body, "body");
+	return new QElement(this._document.body, "body");
 };
 
 Me.prototype.viewport = function viewport() {
@@ -72,7 +70,7 @@ Me.prototype.get = function get(selector, nickname) {
 	ensure.signature(arguments, [String, [undefined, String]]);
 	if (nickname === undefined) nickname = selector;
 
-	var nodes = this.document.querySelectorAll(selector);
+	var nodes = this._document.querySelectorAll(selector);
 	ensure.that(nodes.length === 1, "Expected one element to match '" + selector + "', but found " + nodes.length);
 	return new QElement(nodes[0], nickname);
 };
@@ -82,7 +80,7 @@ Me.prototype.getAll = function getAll(selector, nickname) {
 	ensure.signature(arguments, [String, [undefined, String]]);
 	if (nickname === undefined) nickname = selector;
 
-	return new QElementList(this.document.querySelectorAll(selector), nickname);
+	return new QElementList(this._document.querySelectorAll(selector), nickname);
 };
 
 Me.prototype.scroll = function scroll(x, y) {
@@ -95,7 +93,7 @@ Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
     ensure.signature(arguments, []);
 
 	return {
-		x: shim.Window.pageXOffset(this._window, this.document),
-		y: shim.Window.pageYOffset(this._window, this.document)
+		x: shim.Window.pageXOffset(this._window, this._document),
+		y: shim.Window.pageYOffset(this._window, this._document)
 	};
 };

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -10,8 +10,10 @@ var Me = module.exports = function QContentHost(contentDocument) {
 	// not the top level window's version.
 	ensure.signature(arguments, [ Object ]);
 
-	this._document = contentDocument;
 	this._window = contentDocument.defaultView || contentDocument.parentWindow;
+
+	// public properties
+	this.document = contentDocument;
 };
 
 Me.prototype.toDomElement = function toDomElement() {
@@ -24,7 +26,7 @@ Me.prototype.elementRendered = function elementRendered(element) {
     var QElement = require("./q_element.js");      // break circular dependency
     ensure.signature(arguments, [ QElement ]);
 
-	var inDom = this._document.body.contains(element.toDomElement());
+	var inDom = this.document.body.contains(element.toDomElement());
 	var displayNone = element.getRawStyle("display") === "none";
 
 	return inDom && !displayNone;
@@ -41,7 +43,7 @@ Me.prototype.body = function body() {
 	var QElement = require("./q_element.js");      // break circular dependency
 	ensure.signature(arguments, []);
 
-	return new QElement(this._document.body, "body");
+	return new QElement(this.document.body, "body");
 };
 
 Me.prototype.viewport = function viewport() {
@@ -70,7 +72,7 @@ Me.prototype.get = function get(selector, nickname) {
 	ensure.signature(arguments, [String, [undefined, String]]);
 	if (nickname === undefined) nickname = selector;
 
-	var nodes = this._document.querySelectorAll(selector);
+	var nodes = this.document.querySelectorAll(selector);
 	ensure.that(nodes.length === 1, "Expected one element to match '" + selector + "', but found " + nodes.length);
 	return new QElement(nodes[0], nickname);
 };
@@ -80,7 +82,7 @@ Me.prototype.getAll = function getAll(selector, nickname) {
 	ensure.signature(arguments, [String, [undefined, String]]);
 	if (nickname === undefined) nickname = selector;
 
-	return new QElementList(this._document.querySelectorAll(selector), nickname);
+	return new QElementList(this.document.querySelectorAll(selector), nickname);
 };
 
 Me.prototype.scroll = function scroll(x, y) {
@@ -93,7 +95,7 @@ Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
     ensure.signature(arguments, []);
 
 	return {
-		x: shim.Window.pageXOffset(this._window, this._document),
-		y: shim.Window.pageYOffset(this._window, this._document)
+		x: shim.Window.pageXOffset(this._window, this.document),
+		y: shim.Window.pageYOffset(this._window, this.document)
 	};
 };

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -99,3 +99,14 @@ Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
 		y: shim.Window.pageYOffset(this._window, this.document)
 	};
 };
+
+Me.prototype.addStylesheetLink = function addStylesheetLink(url, onStylesheetLoad) {
+	ensure.signature(arguments, [String, Function]);
+
+	var link = this.document.createElement("link");
+	shim.EventTarget.addEventListener(link, "load", function(event) { onStylesheetLoad(null); });
+	link.setAttribute("rel", "stylesheet");
+	link.setAttribute("type", "text/css");
+	link.setAttribute("href", url);
+	shim.Document.head(this.document).appendChild(link);
+};

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -4,7 +4,7 @@
 var ensure = require("./util/ensure.js");
 var shim = require("./util/shim.js");
 
-var Me = module.exports = function QContent(contentDocument) {
+var Me = module.exports = function QContentHost(contentDocument) {
 	// Cannot check against HTMLDocument directly because most browsers define HTMLDocument on the Window type
 	// Since the document is in an iFrame its HTMLDocument definition is the iFrame window's HTMLDocument and
 	// not the top level window's version.

--- a/src/q_content_host.js
+++ b/src/q_content_host.js
@@ -22,15 +22,6 @@ Me.prototype.toDomElement = function toDomElement() {
     return this._window;
 };
 
-Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
-    ensure.signature(arguments, []);
-
-	return {
-		x: shim.Window.pageXOffset(this._window, this.document),
-		y: shim.Window.pageYOffset(this._window, this.document)
-	};
-};
-
 Me.prototype.elementRendered = function elementRendered(element) {
     var QElement = require("./q_element.js");      // break circular dependency
     ensure.signature(arguments, [ QElement ]);
@@ -50,5 +41,61 @@ Me.prototype.getComputedStyle = function getComputedStyle(element) {
 
 Me.prototype.body = function body() {
 	var QElement = require("./q_element.js");      // break circular dependency
+	ensure.signature(arguments, []);
+
 	return new QElement(this.document.body, "body");
+};
+
+Me.prototype.viewport = function viewport() {
+	var QViewport = require("./q_viewport.js");      // break circular dependency
+	ensure.signature(arguments, []);
+	
+	return new QViewport(this);
+};
+
+Me.prototype.page = function page() {
+	var QPage = require("./q_page.js");      // break circular dependency
+	ensure.signature(arguments, []);
+	
+	return new QPage(this);
+};
+
+Me.prototype.add = function add(html, nickname) {
+	ensure.signature(arguments, [String, [undefined, String]]);
+	if (nickname === undefined) nickname = html;
+
+	return this.body().add(html, nickname);
+};
+
+Me.prototype.get = function get(selector, nickname) {
+	var QElement = require("./q_element.js");      // break circular dependency
+	ensure.signature(arguments, [String, [undefined, String]]);
+	if (nickname === undefined) nickname = selector;
+
+	var nodes = this.document.querySelectorAll(selector);
+	ensure.that(nodes.length === 1, "Expected one element to match '" + selector + "', but found " + nodes.length);
+	return new QElement(nodes[0], nickname);
+};
+
+Me.prototype.getAll = function getAll(selector, nickname) {
+	var QElementList = require("./q_element_list.js");      // break circular dependency
+	ensure.signature(arguments, [String, [undefined, String]]);
+	if (nickname === undefined) nickname = selector;
+
+	return new QElementList(this.document.querySelectorAll(selector), nickname);
+};
+
+Me.prototype.scroll = function scroll(x, y) {
+	ensure.signature(arguments, [Number, Number]);
+
+	this._window.scroll(x, y);
+};
+
+Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
+    ensure.signature(arguments, []);
+
+	return {
+		x: shim.Window.pageXOffset(this._window, this.document),
+		y: shim.Window.pageYOffset(this._window, this.document)
+	};
 };

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -45,7 +45,7 @@ Me.prototype.getRawStyle = function(styleName) {
 	// WORKAROUND IE 8: no getComputedStyle()
 	if (window.getComputedStyle) {
 		// WORKAROUND Firefox 40.0.3: must use frame's contentWindow (ref https://bugzilla.mozilla.org/show_bug.cgi?id=1204062)
-		styles = this.parentWindow().getComputedStyle(this._domElement);
+		styles = this.parentContent().window.getComputedStyle(this._domElement);
 		result = styles.getPropertyValue(styleName);
 	}
 	else {
@@ -148,14 +148,6 @@ Me.prototype.parentDocument = function() {
 	ensure.signature(arguments, []);
 
 	return this._domElement.ownerDocument;
-};
-
-Me.prototype.parentWindow = function() {
-	ensure.signature(arguments, []);
-
-	var parentDocument = this._domElement.ownerDocument;
-	var parentWindow = parentDocument.defaultView || parentDocument.parentWindow;
-	return parentWindow;
 };
 
 Me.prototype.parentContent = function() {

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -11,7 +11,10 @@ var GenericSize = require("./descriptors/generic_size.js");
 var Assertable = require("./assertable.js");
 
 var Me = module.exports = function QElement(domElement, nickname) {
-	ensure.signature(arguments, [Object, String]);
+	ensure.signature(arguments, [Object, [String, undefined]]);
+	if (nickname === undefined) {
+		nickname = domElement.id || domElement.tagName;
+	}
 
 	this._domElement = domElement;
 	this._nickname = nickname;

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -9,6 +9,7 @@ var ElementEdge = require("./descriptors/element_edge.js");
 var Center = require("./descriptors/center.js");
 var GenericSize = require("./descriptors/generic_size.js");
 var Assertable = require("./assertable.js");
+var QContent = require("./q_content.js");
 
 var Me = module.exports = function QElement(domElement, nickname) {
 	ensure.signature(arguments, [Object, [String, undefined]]);
@@ -155,6 +156,12 @@ Me.prototype.parentWindow = function() {
 	var parentDocument = this._domElement.ownerDocument;
 	var parentWindow = parentDocument.defaultView || parentDocument.parentWindow;
 	return parentWindow;
+};
+
+Me.prototype.parentContent = function() {
+	ensure.signature(arguments, []);
+
+	return new QContent(this._domElement.ownerDocument);
 };
 
 Me.prototype.toString = function() {

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -109,8 +109,7 @@ Me.prototype.parent = function(nickname) {
 	ensure.signature(arguments, [[ undefined, String ]]);
 	if (nickname === undefined) nickname = "parent of " + this._nickname;
 
-	var parentDocument = this.host().toDomElement().document;
-	var parentBody = new Me(parentDocument.body, "body");
+	var parentBody = this.host().body();
 	if (this.equals(parentBody)) return null;
 
 	var parent = this._domElement.parentElement;

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -45,7 +45,7 @@ Me.prototype.getRawStyle = function(styleName) {
 	// WORKAROUND IE 8: no getComputedStyle()
 	if (window.getComputedStyle) {
 		// WORKAROUND Firefox 40.0.3: must use frame's contentWindow (ref https://bugzilla.mozilla.org/show_bug.cgi?id=1204062)
-		styles = this.parentContent().window.getComputedStyle(this._domElement);
+		styles = this.parentContent().getComputedStyle(this);
 		result = styles.getPropertyValue(styleName);
 	}
 	else {

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -109,7 +109,8 @@ Me.prototype.parent = function(nickname) {
 	ensure.signature(arguments, [[ undefined, String ]]);
 	if (nickname === undefined) nickname = "parent of " + this._nickname;
 
-	var parentBody = new Me(this.parentDocument().body, "body");
+	var parentDocument = this.parentContent().toDomElement().document;
+	var parentBody = new Me(parentDocument.body, "body");
 	if (this.equals(parentBody)) return null;
 
 	var parent = this._domElement.parentElement;
@@ -142,12 +143,6 @@ Me.prototype.remove = function() {
 Me.prototype.toDomElement = function() {
 	ensure.signature(arguments, []);
 	return this._domElement;
-};
-
-Me.prototype.parentDocument = function() {
-	ensure.signature(arguments, []);
-
-	return this._domElement.ownerDocument;
 };
 
 Me.prototype.parentContent = function() {

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -10,14 +10,11 @@ var Center = require("./descriptors/center.js");
 var GenericSize = require("./descriptors/generic_size.js");
 var Assertable = require("./assertable.js");
 
-var Me = module.exports = function QElement(domElement, frame, nickname) {
-	var QFrame = require("./q_frame.js");    // break circular dependency
-	ensure.signature(arguments, [Object, QFrame, String]);
+var Me = module.exports = function QElement(domElement, nickname) {
+	ensure.signature(arguments, [Object, String]);
 
 	this._domElement = domElement;
 	this._nickname = nickname;
-
-	this.frame = frame;
 
 	// properties
 	this.rendered = ElementRendered.create(this);
@@ -108,13 +105,13 @@ Me.prototype.parent = function(nickname) {
 	ensure.signature(arguments, [[ undefined, String ]]);
 	if (nickname === undefined) nickname = "parent of " + this._nickname;
 
-	var parentBody = new Me(this.parentDocument().body, this.frame, "body");
+	var parentBody = new Me(this.parentDocument().body, "body");
 	if (this.equals(parentBody)) return null;
 
 	var parent = this._domElement.parentElement;
 	if (parent === null) return null;
 
-	return new Me(parent, this.frame, nickname);
+	return new Me(parent, nickname);
 };
 
 Me.prototype.add = function(html, nickname) {
@@ -130,7 +127,7 @@ Me.prototype.add = function(html, nickname) {
 
 	var insertedElement = tempElement.childNodes[0];
 	this._domElement.appendChild(insertedElement);
-	return new Me(insertedElement, this.frame, nickname);
+	return new Me(insertedElement, nickname);
 };
 
 Me.prototype.remove = function() {

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -44,7 +44,7 @@ Me.prototype.getRawStyle = function(styleName) {
 	// WORKAROUND IE 8: no getComputedStyle()
 	if (window.getComputedStyle) {
 		// WORKAROUND Firefox 40.0.3: must use frame's contentWindow (ref https://bugzilla.mozilla.org/show_bug.cgi?id=1204062)
-		styles = this.frame.toDomElement().contentWindow.getComputedStyle(this._domElement);
+		styles = this.parentWindow().getComputedStyle(this._domElement);
 		result = styles.getPropertyValue(styleName);
 	}
 	else {
@@ -108,7 +108,8 @@ Me.prototype.parent = function(nickname) {
 	ensure.signature(arguments, [[ undefined, String ]]);
 	if (nickname === undefined) nickname = "parent of " + this._nickname;
 
-	if (this.equals(this.frame.body())) return null;
+	var parentBody = new Me(this.parentDocument().body, this.frame, "body");
+	if (this.equals(parentBody)) return null;
 
 	var parent = this._domElement.parentElement;
 	if (parent === null) return null;
@@ -140,6 +141,20 @@ Me.prototype.remove = function() {
 Me.prototype.toDomElement = function() {
 	ensure.signature(arguments, []);
 	return this._domElement;
+};
+
+Me.prototype.parentDocument = function() {
+	ensure.signature(arguments, []);
+
+	return this._domElement.ownerDocument;
+};
+
+Me.prototype.parentWindow = function() {
+	ensure.signature(arguments, []);
+
+	var parentDocument = this._domElement.ownerDocument;
+	var parentWindow = parentDocument.defaultView || parentDocument.parentWindow;
+	return parentWindow;
 };
 
 Me.prototype.toString = function() {

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -9,7 +9,7 @@ var ElementEdge = require("./descriptors/element_edge.js");
 var Center = require("./descriptors/center.js");
 var GenericSize = require("./descriptors/generic_size.js");
 var Assertable = require("./assertable.js");
-var QContent = require("./q_content.js");
+var QContentHost = require("./q_content_host.js");
 
 var Me = module.exports = function QElement(domElement, nickname) {
 	ensure.signature(arguments, [Object, [String, undefined]]);
@@ -45,7 +45,7 @@ Me.prototype.getRawStyle = function(styleName) {
 	// WORKAROUND IE 8: no getComputedStyle()
 	if (window.getComputedStyle) {
 		// WORKAROUND Firefox 40.0.3: must use frame's contentWindow (ref https://bugzilla.mozilla.org/show_bug.cgi?id=1204062)
-		styles = this.parentContent().getComputedStyle(this);
+		styles = this.parentContentHost().getComputedStyle(this);
 		result = styles.getPropertyValue(styleName);
 	}
 	else {
@@ -109,7 +109,7 @@ Me.prototype.parent = function(nickname) {
 	ensure.signature(arguments, [[ undefined, String ]]);
 	if (nickname === undefined) nickname = "parent of " + this._nickname;
 
-	var parentDocument = this.parentContent().toDomElement().document;
+	var parentDocument = this.parentContentHost().toDomElement().document;
 	var parentBody = new Me(parentDocument.body, "body");
 	if (this.equals(parentBody)) return null;
 
@@ -145,10 +145,10 @@ Me.prototype.toDomElement = function() {
 	return this._domElement;
 };
 
-Me.prototype.parentContent = function() {
+Me.prototype.parentContentHost = function() {
 	ensure.signature(arguments, []);
 
-	return new QContent(this._domElement.ownerDocument);
+	return new QContentHost(this._domElement.ownerDocument);
 };
 
 Me.prototype.toString = function() {

--- a/src/q_element.js
+++ b/src/q_element.js
@@ -45,7 +45,7 @@ Me.prototype.getRawStyle = function(styleName) {
 	// WORKAROUND IE 8: no getComputedStyle()
 	if (window.getComputedStyle) {
 		// WORKAROUND Firefox 40.0.3: must use frame's contentWindow (ref https://bugzilla.mozilla.org/show_bug.cgi?id=1204062)
-		styles = this.parentContentHost().getComputedStyle(this);
+		styles = this.host().getComputedStyle(this);
 		result = styles.getPropertyValue(styleName);
 	}
 	else {
@@ -109,7 +109,7 @@ Me.prototype.parent = function(nickname) {
 	ensure.signature(arguments, [[ undefined, String ]]);
 	if (nickname === undefined) nickname = "parent of " + this._nickname;
 
-	var parentDocument = this.parentContentHost().toDomElement().document;
+	var parentDocument = this.host().toDomElement().document;
 	var parentBody = new Me(parentDocument.body, "body");
 	if (this.equals(parentBody)) return null;
 
@@ -145,7 +145,7 @@ Me.prototype.toDomElement = function() {
 	return this._domElement;
 };
 
-Me.prototype.parentContentHost = function() {
+Me.prototype.host = function() {
 	ensure.signature(arguments, []);
 
 	return new QContentHost(this._domElement.ownerDocument);

--- a/src/q_element_list.js
+++ b/src/q_element_list.js
@@ -4,12 +4,10 @@
 var ensure = require("./util/ensure.js");
 var QElement = require("./q_element.js");
 
-var Me = module.exports = function QElementList(nodeList, frame, nickname) {
-	var QFrame = require("./q_frame.js");    // break circular dependency
-	ensure.signature(arguments, [ Object, QFrame, String ]);
+var Me = module.exports = function QElementList(nodeList, nickname) {
+	ensure.signature(arguments, [ Object, String ]);
 
 	this._nodeList = nodeList;
-	this._frame = frame;
 	this._nickname = nickname;
 };
 
@@ -33,7 +31,7 @@ Me.prototype.at = function at(requestedIndex, nickname) {
 	var element = this._nodeList[index];
 
 	if (nickname === undefined) nickname = this._nickname + "[" + index + "]";
-	return new QElement(element, this._frame, nickname);
+	return new QElement(element, nickname);
 };
 
 Me.prototype.toString = function toString() {

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -57,7 +57,7 @@ Me.create = function create(parentElement, options, callback) {
 		setTimeout(function() {
 			loaded(frame, width, height, src, stylesheets);
 			loadStylesheets(frame, stylesheets, function() {
-				if (css) loadRawCSS(frame, options.css);
+				if (css) frame._contentHost.addRawStylesheet(options.css);
 				frame._frameLoadCallback(null, frame);
 			});
 		}, 0);
@@ -144,19 +144,6 @@ function loadStylesheets(self, urls, callback) {
 	function addLinkTag(url, onLinkLoad) {
 		self._contentHost.addStylesheetLink(url, onLinkLoad);
 	}
-}
-
-function loadRawCSS(self, css) {
-	var style = document.createElement("style");
-	style.setAttribute("type", "text/css");
-	if (style.styleSheet) {
-		// WORKAROUND IE 8: Throws 'unknown runtime error' if you set innerHTML on a <style> tag
-		style.styleSheet.cssText = css;
-	}
-	else {
-		style.innerHTML = css;
-	}
-	shim.Document.head(self._contentHost.toDomElement().document).appendChild(style);
 }
 
 Me.prototype.reset = function() {

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -4,7 +4,7 @@
 var ensure = require("./util/ensure.js");
 var shim = require("./util/shim.js");
 var quixote = require("./quixote.js");
-var QContent = require("./q_content.js");
+var QContentHost = require("./q_content_host.js");
 var QElement = require("./q_element.js");
 var QElementList = require("./q_element_list.js");
 var QViewport = require("./q_viewport.js");
@@ -21,8 +21,8 @@ var Me = module.exports = function QFrame() {
 
 function loaded(self, width, height, src, stylesheets) {
 	self._loaded = true;
-	self._content = new QContent(self._domElement.contentDocument);
-	self._originalBody = self._content.document.body.innerHTML;
+	self._contentHost = new QContentHost(self._domElement.contentDocument);
+	self._originalBody = self._contentHost.document.body.innerHTML;
 	self._originalWidth = width;
 	self._originalHeight = height;
 	self._originalSrc = src;
@@ -151,7 +151,7 @@ function loadStylesheets(self, urls, callback) {
 		link.setAttribute("rel", "stylesheet");
 		link.setAttribute("type", "text/css");
 		link.setAttribute("href", url);
-		shim.Document.head(self._content.document).appendChild(link);
+		shim.Document.head(self._contentHost.document).appendChild(link);
 	}
 }
 
@@ -165,14 +165,14 @@ function loadRawCSS(self, css) {
 	else {
 		style.innerHTML = css;
 	}
-	shim.Document.head(self._content.document).appendChild(style);
+	shim.Document.head(self._contentHost.document).appendChild(style);
 }
 
 Me.prototype.reset = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	this._content.document.body.innerHTML = this._originalBody;
+	this._contentHost.document.body.innerHTML = this._originalBody;
 	this.scroll(0, 0);
 	this.resize(this._originalWidth, this._originalHeight);
 };
@@ -197,11 +197,11 @@ Me.prototype.toDomElement = function() {
 	return this._domElement;
 };
 
-Me.prototype.toContent = function() {
+Me.prototype.toContentHost = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return this._content;
+	return this._contentHost;
 };
 
 Me.prototype.remove = function() {
@@ -217,14 +217,14 @@ Me.prototype.viewport = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return new QViewport(this._content);
+	return new QViewport(this._contentHost);
 };
 
 Me.prototype.page = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return new QPage(this._content);
+	return new QPage(this._contentHost);
 };
 
 Me.prototype.body = function() {
@@ -245,7 +245,7 @@ Me.prototype.get = function(selector, nickname) {
 	if (nickname === undefined) nickname = selector;
 	ensureUsable(this);
 
-	var nodes = this._content.document.querySelectorAll(selector);
+	var nodes = this._contentHost.document.querySelectorAll(selector);
 	ensure.that(nodes.length === 1, "Expected one element to match '" + selector + "', but found " + nodes.length);
 	return new QElement(nodes[0], nickname);
 };
@@ -255,7 +255,7 @@ Me.prototype.getAll = function(selector, nickname) {
 	if (nickname === undefined) nickname = selector;
 	ensureUsable(this);
 
-	return new QElementList(this._content.document.querySelectorAll(selector), nickname);
+	return new QElementList(this._contentHost.document.querySelectorAll(selector), nickname);
 };
 
 Me.prototype.scroll = function scroll(x, y) {
@@ -270,8 +270,8 @@ Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
 	ensureUsable(this);
 
 	return {
-		x: shim.Window.pageXOffset(this._domElement.contentWindow, this._content.document),
-		y: shim.Window.pageYOffset(this._domElement.contentWindow, this._content.document)
+		x: shim.Window.pageXOffset(this._domElement.contentWindow, this._contentHost.document),
+		y: shim.Window.pageYOffset(this._domElement.contentWindow, this._contentHost.document)
 	};
 };
 

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -142,12 +142,7 @@ function loadStylesheets(self, urls, callback) {
 	async.each(urls, addLinkTag, callback);
 
 	function addLinkTag(url, onLinkLoad) {
-		var link = document.createElement("link");
-		shim.EventTarget.addEventListener(link, "load", function(event) { onLinkLoad(null); });
-		link.setAttribute("rel", "stylesheet");
-		link.setAttribute("type", "text/css");
-		link.setAttribute("href", url);
-		shim.Document.head(self._contentHost.toDomElement().document).appendChild(link);
+		self._contentHost.addStylesheetLink(url, onLinkLoad);
 	}
 }
 

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -4,6 +4,7 @@
 var ensure = require("./util/ensure.js");
 var shim = require("./util/shim.js");
 var quixote = require("./quixote.js");
+var QContent = require("./q_content.js");
 var QElement = require("./q_element.js");
 var QElementList = require("./q_element_list.js");
 var QViewport = require("./q_viewport.js");
@@ -20,8 +21,8 @@ var Me = module.exports = function QFrame() {
 
 function loaded(self, width, height, src, stylesheets) {
 	self._loaded = true;
-	self._document = self._domElement.contentDocument;
-	self._originalBody = self._document.body.innerHTML;
+	self._content = new QContent(self._domElement.contentDocument);
+	self._originalBody = self._content.document.body.innerHTML;
 	self._originalWidth = width;
 	self._originalHeight = height;
 	self._originalSrc = src;
@@ -150,7 +151,7 @@ function loadStylesheets(self, urls, callback) {
 		link.setAttribute("rel", "stylesheet");
 		link.setAttribute("type", "text/css");
 		link.setAttribute("href", url);
-		shim.Document.head(self._document).appendChild(link);
+		shim.Document.head(self._content.document).appendChild(link);
 	}
 }
 
@@ -164,14 +165,14 @@ function loadRawCSS(self, css) {
 	else {
 		style.innerHTML = css;
 	}
-	shim.Document.head(self._document).appendChild(style);
+	shim.Document.head(self._content.document).appendChild(style);
 }
 
 Me.prototype.reset = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	this._document.body.innerHTML = this._originalBody;
+	this._content.document.body.innerHTML = this._originalBody;
 	this.scroll(0, 0);
 	this.resize(this._originalWidth, this._originalHeight);
 };
@@ -196,6 +197,13 @@ Me.prototype.toDomElement = function() {
 	return this._domElement;
 };
 
+Me.prototype.toContent = function() {
+	ensure.signature(arguments, []);
+	ensureUsable(this);
+
+	return this._content;
+};
+
 Me.prototype.remove = function() {
 	ensure.signature(arguments, []);
 	ensureLoaded(this);
@@ -216,7 +224,7 @@ Me.prototype.page = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return new QPage(this._document);
+	return new QPage(this._content);
 };
 
 Me.prototype.body = function() {
@@ -237,7 +245,7 @@ Me.prototype.get = function(selector, nickname) {
 	if (nickname === undefined) nickname = selector;
 	ensureUsable(this);
 
-	var nodes = this._document.querySelectorAll(selector);
+	var nodes = this._content.document.querySelectorAll(selector);
 	ensure.that(nodes.length === 1, "Expected one element to match '" + selector + "', but found " + nodes.length);
 	return new QElement(nodes[0], nickname);
 };
@@ -247,7 +255,7 @@ Me.prototype.getAll = function(selector, nickname) {
 	if (nickname === undefined) nickname = selector;
 	ensureUsable(this);
 
-	return new QElementList(this._document.querySelectorAll(selector), nickname);
+	return new QElementList(this._content.document.querySelectorAll(selector), nickname);
 };
 
 Me.prototype.scroll = function scroll(x, y) {
@@ -262,8 +270,8 @@ Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
 	ensureUsable(this);
 
 	return {
-		x: shim.Window.pageXOffset(this._domElement.contentWindow, this._document),
-		y: shim.Window.pageYOffset(this._domElement.contentWindow, this._document)
+		x: shim.Window.pageXOffset(this._domElement.contentWindow, this._content.document),
+		y: shim.Window.pageYOffset(this._domElement.contentWindow, this._content.document)
 	};
 };
 

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -5,10 +5,6 @@ var ensure = require("./util/ensure.js");
 var shim = require("./util/shim.js");
 var quixote = require("./quixote.js");
 var QContentHost = require("./q_content_host.js");
-var QElement = require("./q_element.js");
-var QElementList = require("./q_element_list.js");
-var QViewport = require("./q_viewport.js");
-var QPage = require("./q_page.js");
 var async = require("../vendor/async-1.4.2.js");
 
 var Me = module.exports = function QFrame() {
@@ -151,7 +147,7 @@ function loadStylesheets(self, urls, callback) {
 		link.setAttribute("rel", "stylesheet");
 		link.setAttribute("type", "text/css");
 		link.setAttribute("href", url);
-		shim.Document.head(self._contentHost.document).appendChild(link);
+		shim.Document.head(self._contentHost.toDomElement().document).appendChild(link);
 	}
 }
 
@@ -165,14 +161,14 @@ function loadRawCSS(self, css) {
 	else {
 		style.innerHTML = css;
 	}
-	shim.Document.head(self._contentHost.document).appendChild(style);
+	shim.Document.head(self._contentHost.toDomElement().document).appendChild(style);
 }
 
 Me.prototype.reset = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	this._contentHost.document.body.innerHTML = this._originalBody;
+	this._contentHost.toDomElement().document.body.innerHTML = this._originalBody;
 	this.scroll(0, 0);
 	this.resize(this._originalWidth, this._originalHeight);
 };
@@ -214,65 +210,51 @@ Me.prototype.remove = function() {
 };
 
 Me.prototype.viewport = function() {
-	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return new QViewport(this._contentHost);
+	return this._contentHost.viewport();
 };
 
 Me.prototype.page = function() {
-	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return new QPage(this._contentHost);
+	return this._contentHost.page();
 };
 
 Me.prototype.body = function() {
-	ensure.signature(arguments, []);
+	ensureUsable(this);
 
-	return this.get("body");
+	return this._contentHost.body();
 };
 
 Me.prototype.add = function(html, nickname) {
-	ensure.signature(arguments, [String, [undefined, String]]);
-	if (nickname === undefined) nickname = html;
+	ensureUsable(this);
 
-	return this.body().add(html, nickname);
+	return this._contentHost.add(html, nickname);
 };
 
 Me.prototype.get = function(selector, nickname) {
-	ensure.signature(arguments, [String, [undefined, String]]);
-	if (nickname === undefined) nickname = selector;
 	ensureUsable(this);
 
-	var nodes = this._contentHost.document.querySelectorAll(selector);
-	ensure.that(nodes.length === 1, "Expected one element to match '" + selector + "', but found " + nodes.length);
-	return new QElement(nodes[0], nickname);
+	return this._contentHost.get(selector, nickname);
 };
 
 Me.prototype.getAll = function(selector, nickname) {
-	ensure.signature(arguments, [String, [undefined, String]]);
-	if (nickname === undefined) nickname = selector;
 	ensureUsable(this);
 
-	return new QElementList(this._contentHost.document.querySelectorAll(selector), nickname);
+	return this._contentHost.getAll(selector, nickname);
 };
 
 Me.prototype.scroll = function scroll(x, y) {
-	ensure.signature(arguments, [Number, Number]);
 	ensureUsable(this);
 
-	this._domElement.contentWindow.scroll(x, y);
+	return this._contentHost.scroll(x, y);
 };
 
 Me.prototype.getRawScrollPosition = function getRawScrollPosition() {
-	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return {
-		x: shim.Window.pageXOffset(this._domElement.contentWindow, this._contentHost.document),
-		y: shim.Window.pageYOffset(this._domElement.contentWindow, this._contentHost.document)
-	};
+	return this._contentHost.getRawScrollPosition();
 };
 
 Me.prototype.resize = function resize(width, height) {

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -239,7 +239,7 @@ Me.prototype.get = function(selector, nickname) {
 
 	var nodes = this._document.querySelectorAll(selector);
 	ensure.that(nodes.length === 1, "Expected one element to match '" + selector + "', but found " + nodes.length);
-	return new QElement(nodes[0], this, nickname);
+	return new QElement(nodes[0], nickname);
 };
 
 Me.prototype.getAll = function(selector, nickname) {
@@ -247,7 +247,7 @@ Me.prototype.getAll = function(selector, nickname) {
 	if (nickname === undefined) nickname = selector;
 	ensureUsable(this);
 
-	return new QElementList(this._document.querySelectorAll(selector), this, nickname);
+	return new QElementList(this._document.querySelectorAll(selector), nickname);
 };
 
 Me.prototype.scroll = function scroll(x, y) {

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -18,7 +18,7 @@ var Me = module.exports = function QFrame() {
 function loaded(self, width, height, src, stylesheets) {
 	self._loaded = true;
 	self._contentHost = new QContentHost(self._domElement.contentDocument);
-	self._originalBody = self._contentHost.toDomElement().document.body.innerHTML;
+	self._originalBody = self._contentHost.body().toDomElement().innerHTML;
 	self._originalWidth = width;
 	self._originalHeight = height;
 	self._originalSrc = src;
@@ -168,7 +168,7 @@ Me.prototype.reset = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	this._contentHost.toDomElement().document.body.innerHTML = this._originalBody;
+	this._contentHost.body().toDomElement().innerHTML = this._originalBody;
 	this.scroll(0, 0);
 	this.resize(this._originalWidth, this._originalHeight);
 };

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -217,7 +217,7 @@ Me.prototype.viewport = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return new QViewport(this);
+	return new QViewport(this._content);
 };
 
 Me.prototype.page = function() {

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -216,7 +216,7 @@ Me.prototype.page = function() {
 	ensure.signature(arguments, []);
 	ensureUsable(this);
 
-	return new QPage(this);
+	return new QPage(this._document);
 };
 
 Me.prototype.body = function() {

--- a/src/q_frame.js
+++ b/src/q_frame.js
@@ -18,7 +18,7 @@ var Me = module.exports = function QFrame() {
 function loaded(self, width, height, src, stylesheets) {
 	self._loaded = true;
 	self._contentHost = new QContentHost(self._domElement.contentDocument);
-	self._originalBody = self._contentHost.document.body.innerHTML;
+	self._originalBody = self._contentHost.toDomElement().document.body.innerHTML;
 	self._originalWidth = width;
 	self._originalHeight = height;
 	self._originalSrc = src;

--- a/src/q_page.js
+++ b/src/q_page.js
@@ -6,18 +6,16 @@ var PageEdge = require("./descriptors/page_edge.js");
 var Center = require("./descriptors/center.js");
 var Assertable = require("./assertable.js");
 var GenericSize = require("./descriptors/generic_size.js");
+var QContent = require("./q_content.js");
 
-var Me = module.exports = function QPage(contentDocument) {
-	// Cannot check against HTMLDocument directly because most browsers define HTMLDocument on the Window type
-	// Since the document is in an iFrame its HTMLDocument definition is the iFrame window's HTMLDocument and
-	// not the top level window's version.
-	ensure.signature(arguments, [ Object ]);
+var Me = module.exports = function QPage(content) {
+	ensure.signature(arguments, [ QContent ]);
 
 	// properties
-	this.top = PageEdge.top(contentDocument);
-	this.right = PageEdge.right(contentDocument);
-	this.bottom = PageEdge.bottom(contentDocument);
-	this.left = PageEdge.left(contentDocument);
+	this.top = PageEdge.top(content);
+	this.right = PageEdge.right(content);
+	this.bottom = PageEdge.bottom(content);
+	this.left = PageEdge.left(content);
 
 	this.width = GenericSize.create(this.left, this.right, "width of page");
 	this.height = GenericSize.create(this.top, this.bottom, "height of page");

--- a/src/q_page.js
+++ b/src/q_page.js
@@ -7,15 +7,17 @@ var Center = require("./descriptors/center.js");
 var Assertable = require("./assertable.js");
 var GenericSize = require("./descriptors/generic_size.js");
 
-var Me = module.exports = function QPage(frame) {
-	var QFrame = require("./q_frame.js");   // break circular dependency
-	ensure.signature(arguments, [ QFrame ]);
+var Me = module.exports = function QPage(contentDocument) {
+	// Cannot check against HTMLDocument directly because most browsers define HTMLDocument on the Window type
+	// Since the document is in an iFrame its HTMLDocument definition is the iFrame window's HTMLDocument and
+	// not the top level window's version.
+	ensure.signature(arguments, [ Object ]);
 
 	// properties
-	this.top = PageEdge.top(frame);
-	this.right = PageEdge.right(frame);
-	this.bottom = PageEdge.bottom(frame);
-	this.left = PageEdge.left(frame);
+	this.top = PageEdge.top(contentDocument);
+	this.right = PageEdge.right(contentDocument);
+	this.bottom = PageEdge.bottom(contentDocument);
+	this.left = PageEdge.left(contentDocument);
 
 	this.width = GenericSize.create(this.left, this.right, "width of page");
 	this.height = GenericSize.create(this.top, this.bottom, "height of page");

--- a/src/q_page.js
+++ b/src/q_page.js
@@ -6,16 +6,16 @@ var PageEdge = require("./descriptors/page_edge.js");
 var Center = require("./descriptors/center.js");
 var Assertable = require("./assertable.js");
 var GenericSize = require("./descriptors/generic_size.js");
-var QContent = require("./q_content.js");
+var QContentHost = require("./q_content_host.js");
 
-var Me = module.exports = function QPage(content) {
-	ensure.signature(arguments, [ QContent ]);
+var Me = module.exports = function QPage(contentHost) {
+	ensure.signature(arguments, [ QContentHost ]);
 
 	// properties
-	this.top = PageEdge.top(content);
-	this.right = PageEdge.right(content);
-	this.bottom = PageEdge.bottom(content);
-	this.left = PageEdge.left(content);
+	this.top = PageEdge.top(contentHost);
+	this.right = PageEdge.right(contentHost);
+	this.bottom = PageEdge.bottom(contentHost);
+	this.left = PageEdge.left(contentHost);
 
 	this.width = GenericSize.create(this.left, this.right, "width of page");
 	this.height = GenericSize.create(this.top, this.bottom, "height of page");

--- a/src/q_viewport.js
+++ b/src/q_viewport.js
@@ -6,16 +6,16 @@ var ViewportEdge = require("./descriptors/viewport_edge.js");
 var Center = require("./descriptors/center.js");
 var Assertable = require("./assertable.js");
 var GenericSize = require("./descriptors/generic_size.js");
-var QContent = require("./q_content.js");
+var QContentHost = require("./q_content_host.js");
 
-var Me = module.exports = function QViewport(content) {
-	ensure.signature(arguments, [ QContent ]);
+var Me = module.exports = function QViewport(contentHost) {
+	ensure.signature(arguments, [ QContentHost ]);
 
 	// properties
-	this.top = ViewportEdge.top(content);
-	this.right = ViewportEdge.right(content);
-	this.bottom = ViewportEdge.bottom(content);
-	this.left = ViewportEdge.left(content);
+	this.top = ViewportEdge.top(contentHost);
+	this.right = ViewportEdge.right(contentHost);
+	this.bottom = ViewportEdge.bottom(contentHost);
+	this.left = ViewportEdge.left(contentHost);
 
 	this.width = GenericSize.create(this.left, this.right, "width of viewport");
 	this.height = GenericSize.create(this.top, this.bottom, "height of viewport");

--- a/src/q_viewport.js
+++ b/src/q_viewport.js
@@ -6,16 +6,16 @@ var ViewportEdge = require("./descriptors/viewport_edge.js");
 var Center = require("./descriptors/center.js");
 var Assertable = require("./assertable.js");
 var GenericSize = require("./descriptors/generic_size.js");
+var QContent = require("./q_content.js");
 
-var Me = module.exports = function QViewport(frame) {
-	var QFrame = require("./q_frame.js");   // break circular dependency
-	ensure.signature(arguments, [ QFrame ]);
+var Me = module.exports = function QViewport(content) {
+	ensure.signature(arguments, [ QContent ]);
 
 	// properties
-	this.top = ViewportEdge.top(frame);
-	this.right = ViewportEdge.right(frame);
-	this.bottom = ViewportEdge.bottom(frame);
-	this.left = ViewportEdge.left(frame);
+	this.top = ViewportEdge.top(content);
+	this.right = ViewportEdge.right(content);
+	this.bottom = ViewportEdge.bottom(content);
+	this.left = ViewportEdge.left(content);
 
 	this.width = GenericSize.create(this.left, this.right, "width of viewport");
 	this.height = GenericSize.create(this.top, this.bottom, "height of viewport");

--- a/src/quixote.js
+++ b/src/quixote.js
@@ -2,6 +2,7 @@
 "use strict";
 
 var ensure = require("./util/ensure.js");
+var QElement = require('./q_element.js');
 var QFrame = require("./q_frame.js");
 var Size = require("./values/size.js");
 
@@ -18,6 +19,10 @@ exports.createFrame = function(options, callback) {
 			callback(err, callbackFrame);
 		}
 	});
+};
+
+exports.elementFromDom = function(domElement, nickname) {
+	return new QElement(domElement, nickname);
 };
 
 exports.browser = {};


### PR DESCRIPTION
This is a work in progress towards this suggested enhancement https://github.com/jamesshore/quixote/issues/55

So far it just demonstrates how to remove QFrame from QElement. I believe it works as expected, I am on windows so only was able to run the tests in chrome, firefox, and edge. At least those three browsers reported success.

I also want to test using this in cypress to make sure it works as expected over there. Will try and get to that in the next couple of days.